### PR TITLE
Change TargetMap type from boxed to generic, calculate total dedup ratio

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,12 +48,12 @@ extern crate chunkfs;
 use std::io;
 use std::collections::HashMap;
 use chunkfs::chunkers::LeapChunker;
-use chunkfs::FileSystem;
+use chunkfs::{FileSystem, create_cdc_filesystem};
 use chunkfs::hashers::SimpleHasher;
 
 fn main() -> io::Result<()> {
     let base = HashMap::default();
-    let mut fs = FileSystem::new_with_key(base, SimpleHasher, 0);
+    let mut fs = create_cdc_filesystem(base, SimpleHasher, 0);
 
     let mut file = fs.create_file("file", LeapChunker::default(), true)?;
     let data = vec![10; 1024 * 1024];
@@ -75,7 +75,7 @@ Getting Scrubber measurements:
 fn main() -> io::Result<()> {
     let mut fs = FileSystem::new_with_scrubber(
         HashMap::default(),
-        Box::new(SBCMap::new()),
+        SBCMap::new(),
         Box::new(SBCScrubber::new()),
         Sha256Hasher::default()
     );

--- a/benches/write_read.rs
+++ b/benches/write_read.rs
@@ -6,8 +6,8 @@ use criterion::measurement::WallTime;
 use criterion::{criterion_group, BatchSize, BenchmarkGroup, BenchmarkId, Criterion, Throughput};
 
 use chunkfs::chunkers::UltraChunker;
+use chunkfs::create_cdc_filesystem;
 use chunkfs::hashers::Sha256Hasher;
-use chunkfs::FileSystem;
 
 struct Dataset<'a> {
     path: &'a str,
@@ -46,7 +46,7 @@ fn bench_write(dataset: &Dataset, group: &mut BenchmarkGroup<WallTime>, data: &[
         b.iter_batched(
             || {
                 let base = HashMap::default();
-                let mut fs = FileSystem::new_with_key(base, Sha256Hasher::default(), 0);
+                let mut fs = create_cdc_filesystem(base, Sha256Hasher::default());
 
                 let chunker = UltraChunker::default();
                 let handle = fs.create_file("file", chunker, true).unwrap();
@@ -67,7 +67,7 @@ fn bench_read(dataset: &Dataset, group: &mut BenchmarkGroup<WallTime>, data: &[u
         b.iter_batched(
             || {
                 let base = HashMap::default();
-                let mut fs = FileSystem::new_with_key(base, Sha256Hasher::default(), 0);
+                let mut fs = create_cdc_filesystem(base, Sha256Hasher::default());
 
                 let chunker = UltraChunker::default();
                 let mut handle = fs.create_file("file", chunker, true).unwrap();

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -8,8 +8,8 @@ use std::time::{Duration, Instant};
 
 use chunkfs::chunkers::LeapChunker;
 use chunkfs::hashers::SimpleHasher;
-use chunkfs::{create_cdc_filesystem, Chunker};
 use chunkfs::Hasher;
+use chunkfs::{create_cdc_filesystem, Chunker};
 
 #[derive(Default)]
 struct Measurements {
@@ -21,7 +21,7 @@ struct Measurements {
 
 fn main() -> io::Result<()> {
     let base = HashMap::default();
-    let mut fs = create_cdc_filesystem(base, SimpleHasher, 0);
+    let mut fs = create_cdc_filesystem(base, SimpleHasher);
 
     let mut file = fs.create_file("file", LeapChunker::default(), true)?;
     let data = vec![10; 1024 * 1024];
@@ -72,7 +72,7 @@ fn parametrized_write(
     println!("Current hasher: {:?}", hasher);
 
     let base = HashMap::default();
-    let mut fs = create_cdc_filesystem(base, hasher, 0);
+    let mut fs = create_cdc_filesystem(base, hasher);
 
     let mut handle = fs.create_file("file", chunker, true)?;
 

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -8,8 +8,7 @@ use std::time::{Duration, Instant};
 
 use chunkfs::chunkers::LeapChunker;
 use chunkfs::hashers::SimpleHasher;
-use chunkfs::Chunker;
-use chunkfs::FileSystem;
+use chunkfs::{create_cdc_filesystem, Chunker};
 use chunkfs::Hasher;
 
 #[derive(Default)]
@@ -22,7 +21,7 @@ struct Measurements {
 
 fn main() -> io::Result<()> {
     let base = HashMap::default();
-    let mut fs = FileSystem::new_with_key(base, SimpleHasher, 0);
+    let mut fs = create_cdc_filesystem(base, SimpleHasher, 0);
 
     let mut file = fs.create_file("file", LeapChunker::default(), true)?;
     let data = vec![10; 1024 * 1024];
@@ -73,7 +72,7 @@ fn parametrized_write(
     println!("Current hasher: {:?}", hasher);
 
     let base = HashMap::default();
-    let mut fs = FileSystem::new_with_key(base, hasher, 0);
+    let mut fs = create_cdc_filesystem(base, hasher, 0);
 
     let mut handle = fs.create_file("file", chunker, true)?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 pub use map::Database;
 pub use scrub::{CopyScrubber, Scrub, ScrubMeasurements};
 pub use storage::{Data, DataContainer};
-pub use system::FileSystem;
+pub use system::{FileSystem, create_cdc_filesystem};
 
 #[cfg(feature = "chunkers")]
 pub mod chunkers;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 pub use map::Database;
 pub use scrub::{CopyScrubber, Scrub, ScrubMeasurements};
 pub use storage::{Data, DataContainer};
-pub use system::{FileSystem, create_cdc_filesystem};
+pub use system::{create_cdc_filesystem, FileSystem};
 
 #[cfg(feature = "chunkers")]
 pub mod chunkers;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@ use std::hash;
 use std::ops::{Add, AddAssign};
 use std::time::Duration;
 
-pub use map::Database;
+pub use map::{Database, IterableDatabase};
 pub use scrub::{CopyScrubber, Scrub, ScrubMeasurements};
 pub use storage::{Data, DataContainer};
 pub use system::{create_cdc_filesystem, FileSystem};

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,6 +1,5 @@
 use std::fmt::Formatter;
 use std::io;
-use std::marker::PhantomData;
 use std::time::{Duration, Instant};
 
 use crate::map::{Database, IterableDatabase};
@@ -330,38 +329,6 @@ impl<K> std::fmt::Debug for Data<K> {
 impl<K> Default for Data<K> {
     fn default() -> Self {
         Self::Chunk(vec![])
-    }
-}
-
-pub struct EmptyDatabase<K, V> {
-    k: PhantomData<K>,
-    v: PhantomData<V>,
-}
-
-impl<K, V> EmptyDatabase<K, V> {
-    pub fn new(_key: K, _value: V) -> Self {
-        Self {
-            k: Default::default(),
-            v: Default::default(),
-        }
-    }
-}
-
-impl<K, V> Database<K, V> for EmptyDatabase<K, V> {
-    fn insert(&mut self, _key: K, _value: V) -> io::Result<()> {
-        unimplemented!()
-    }
-
-    fn get(&self, _key: &K) -> io::Result<V> {
-        unimplemented!()
-    }
-
-    fn remove(&mut self, _key: &K) {
-        unimplemented!()
-    }
-
-    fn contains(&self, _key: &K) -> bool {
-        unimplemented!()
     }
 }
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -144,7 +144,12 @@ where
     pub fn scrub(&mut self) -> io::Result<ScrubMeasurements> {
         self.scrubber
             .as_mut()
-            .ok_or(io::Error::new(io::ErrorKind::InvalidInput, "scrubber cannot be used with CDC filesystem"))?
+            .ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "scrubber cannot be used with CDC filesystem",
+                )
+            })?
             .scrub(&mut self.database, &mut self.target_map)
     }
 
@@ -389,10 +394,7 @@ mod tests {
             .scrubber
             .as_mut()
             .unwrap()
-            .scrub(
-                &mut chunk_storage.database,
-                &mut chunk_storage.target_map,
-            )
+            .scrub(&mut chunk_storage.database, &mut chunk_storage.target_map)
             .unwrap();
         assert_eq!(measurements, ScrubMeasurements::default());
 
@@ -401,8 +403,11 @@ mod tests {
 
     #[test]
     fn total_cdc_size_is_calculated_correctly_for_fixed_size_chunker_on_simple_data() {
-        let mut chunk_storage =
-            ChunkStorage::new(HashMap::<Vec<u8>, DataContainer<()>>::new(), SimpleHasher, HashMap::default());
+        let mut chunk_storage = ChunkStorage::new(
+            HashMap::<Vec<u8>, DataContainer<()>>::new(),
+            SimpleHasher,
+            HashMap::default(),
+        );
 
         let data = vec![10; 1024 * 1024];
         let mut chunker: Box<dyn Chunker> = Box::new(FSChunker::new(4096));
@@ -415,8 +420,11 @@ mod tests {
 
     #[test]
     fn size_written_is_calculated_correctly() {
-        let mut chunk_storage: ChunkStorage<SimpleHasher, Vec<u8>, HashMap<Vec<u8>, DataContainer<()>>, (), HashMap<_, _>> =
-            ChunkStorage::new(HashMap::<Vec<u8>, DataContainer<()>>::new(), SimpleHasher, HashMap::default());
+        let mut chunk_storage = ChunkStorage::new(
+            HashMap::<Vec<u8>, DataContainer<()>>::new(),
+            SimpleHasher,
+            HashMap::default(),
+        );
 
         let data = [
             vec![4; 1024 * 256],

--- a/src/system.rs
+++ b/src/system.rs
@@ -140,7 +140,7 @@ where
 {
     /// Creates a file system with the given [`hasher`][Hasher], original [`database`][Database] and target map, and a [`scrubber`][Scrub].
     ///
-    /// Provided `database` must implement [IterableDatabase].
+    /// Provided `database` must implement [`IterableDatabase`].
     pub fn new_with_scrubber(
         database: B,
         target_map: T,

--- a/src/system.rs
+++ b/src/system.rs
@@ -1,5 +1,6 @@
 use std::cmp::min;
 use std::io;
+
 use crate::file_layer::{FileHandle, FileLayer};
 use crate::map::{Database, IterableDatabase};
 use crate::scrub::{Scrub, ScrubMeasurements};
@@ -26,7 +27,10 @@ where
 ///
 /// If database is iterable (e.g. `HashMap` or something that implements [`IterableDatabase`]),
 /// CDC dedup ratio can be calculated using [`cdc_dedup_ratio`][FileSystem::cdc_dedup_ratio].
-pub fn create_cdc_filesystem<B, H, Hash>(base: B, hasher: H) -> FileSystem<B, H, Hash, (), EmptyDatabase<(), Vec<u8>>>
+pub fn create_cdc_filesystem<B, H, Hash>(
+    base: B,
+    hasher: H,
+) -> FileSystem<B, H, Hash, (), EmptyDatabase<(), Vec<u8>>>
 where
     B: Database<Hash, DataContainer<()>>,
     H: Hasher<Hash = Hash>,

--- a/src/system.rs
+++ b/src/system.rs
@@ -1,10 +1,11 @@
 use std::cmp::min;
+use std::collections::HashMap;
 use std::io;
 
 use crate::file_layer::{FileHandle, FileLayer};
 use crate::map::{Database, IterableDatabase};
 use crate::scrub::{Scrub, ScrubMeasurements};
-use crate::storage::{ChunkStorage, DataContainer, EmptyDatabase};
+use crate::storage::{ChunkStorage, DataContainer};
 use crate::WriteMeasurements;
 use crate::{ChunkHash, SEG_SIZE};
 use crate::{Chunker, Hasher};
@@ -34,13 +35,13 @@ where
 pub fn create_cdc_filesystem<B, H, Hash>(
     base: B,
     hasher: H,
-) -> FileSystem<B, H, Hash, (), EmptyDatabase<(), Vec<u8>>>
+) -> FileSystem<B, H, Hash, (), HashMap<(), Vec<u8>>>
 where
     B: Database<Hash, DataContainer<()>>,
     H: Hasher<Hash = Hash>,
     Hash: ChunkHash,
 {
-    FileSystem::new(base, hasher, EmptyDatabase::new((), vec![]))
+    FileSystem::new(base, hasher, HashMap::default())
 }
 
 impl<B, H, Hash, K, T> FileSystem<B, H, Hash, K, T>

--- a/src/system.rs
+++ b/src/system.rs
@@ -10,6 +10,10 @@ use crate::{ChunkHash, SEG_SIZE};
 use crate::{Chunker, Hasher};
 
 /// A file system provided by chunkfs.
+///
+/// To create a file system that can be used with CDC algorithms only, [`create_cdc_filesystem`] should be used.
+///
+/// If you want to test scrubber, [`FileSystem::new_with_scrubber`] should be used.
 pub struct FileSystem<B, H, Hash, K, T>
 where
     B: Database<Hash, DataContainer<K>>,
@@ -133,9 +137,9 @@ where
     Hash: ChunkHash,
     T: Database<K, Vec<u8>>,
 {
-    /// Creates a file system with the given [`hasher`][Hasher], original [`base`][Base] and target map, and a [`scrubber`][Scrub].
+    /// Creates a file system with the given [`hasher`][Hasher], original [`database`][Database] and target map, and a [`scrubber`][Scrub].
     ///
-    /// Provided `database` must implement [IntoIterator].
+    /// Provided `database` must implement [IterableDatabase].
     pub fn new_with_scrubber(
         database: B,
         target_map: T,

--- a/tests/filesystem.rs
+++ b/tests/filesystem.rs
@@ -113,10 +113,6 @@ fn non_iterable_database_can_be_used_with_fs() {
             unimplemented!()
         }
 
-        fn remove(&mut self, _key: &Vec<u8>) {
-            unimplemented!()
-        }
-
         fn contains(&self, _key: &Vec<u8>) -> bool {
             unimplemented!()
         }

--- a/tests/filesystem.rs
+++ b/tests/filesystem.rs
@@ -13,7 +13,7 @@ const MB: usize = 1024 * 1024;
 
 #[test]
 fn write_read_complete_test() {
-    let mut fs = create_cdc_filesystem(HashMap::default(), SimpleHasher, 0);
+    let mut fs = create_cdc_filesystem(HashMap::default(), SimpleHasher);
 
     let mut handle = fs
         .create_file("file", LeapChunker::default(), true)
@@ -32,7 +32,7 @@ fn write_read_complete_test() {
 
 #[test]
 fn write_read_blocks_test() {
-    let mut fs = create_cdc_filesystem(HashMap::default(), SimpleHasher, 0);
+    let mut fs = create_cdc_filesystem(HashMap::default(), SimpleHasher);
 
     let mut handle = fs.create_file("file", FSChunker::new(4096), true).unwrap();
 
@@ -53,7 +53,7 @@ fn write_read_blocks_test() {
 
 #[test]
 fn read_file_with_size_less_than_1mb() {
-    let mut fs = create_cdc_filesystem(HashMap::default(), SimpleHasher, 0);
+    let mut fs = create_cdc_filesystem(HashMap::default(), SimpleHasher);
 
     let mut handle = fs.create_file("file", FSChunker::new(4096), true).unwrap();
 
@@ -68,7 +68,7 @@ fn read_file_with_size_less_than_1mb() {
 
 #[test]
 fn write_read_big_file_at_once() {
-    let mut fs = create_cdc_filesystem(HashMap::default(), SimpleHasher, 0);
+    let mut fs = create_cdc_filesystem(HashMap::default(), SimpleHasher);
 
     let mut handle = fs.create_file("file", FSChunker::new(4096), true).unwrap();
 
@@ -82,7 +82,7 @@ fn write_read_big_file_at_once() {
 
 #[test]
 fn scrub_compiles_on_cdc_map_but_returns_error() {
-    let mut fs = create_cdc_filesystem(HashMap::default(), SimpleHasher, 0);
+    let mut fs = create_cdc_filesystem(HashMap::default(), SimpleHasher);
     let result = fs.scrub();
     assert!(result.is_err());
     assert_eq!(result.unwrap_err().kind(), ErrorKind::InvalidInput)
@@ -90,7 +90,7 @@ fn scrub_compiles_on_cdc_map_but_returns_error() {
 
 #[test]
 fn two_file_handles_to_one_file() {
-    let mut fs = create_cdc_filesystem(HashMap::default(), SimpleHasher, 0);
+    let mut fs = create_cdc_filesystem(HashMap::default(), SimpleHasher);
     let mut handle1 = fs
         .create_file("file", LeapChunker::default(), true)
         .unwrap();
@@ -122,12 +122,12 @@ fn non_iterable_database_can_be_used_with_fs() {
         }
     }
 
-    let _ = create_cdc_filesystem(DummyDatabase, SimpleHasher, ());
+    let _ = create_cdc_filesystem(DummyDatabase, SimpleHasher);
 }
 
 #[test]
 fn dedup_ratio_is_correct_for_fixed_size_chunker() {
-    let mut fs = create_cdc_filesystem(HashMap::new(), SimpleHasher, 9);
+    let mut fs = create_cdc_filesystem(HashMap::new(), SimpleHasher);
 
     const MB: usize = 1024 * 1024;
     const CHUNK_SIZE: usize = 4096;
@@ -162,7 +162,7 @@ fn dedup_ratio_is_correct_for_fixed_size_chunker() {
 
 #[test]
 fn different_chunkers_from_vec_can_be_used_with_same_filesystem() {
-    let mut fs = create_cdc_filesystem(HashMap::new(), Sha256Hasher::default(), 9);
+    let mut fs = create_cdc_filesystem(HashMap::new(), Sha256Hasher::default());
     let chunkers: Vec<Box<dyn chunkfs::Chunker>> = vec![
         SuperChunker::default().into(),
         LeapChunker::default().into(),


### PR DESCRIPTION
This was done in order to add a total_dedup_ratio function, which calculates dedup ratio for both scrubber and unscrubbed data, but in the process some changes had to be made.

The most notable is that now CDC filesystem creation is too ugly via the associated FileSystem methods, which now also require a user to provide a target map, which is useless for that use case. So I made a create_cdc_filesystem static function which does exactly what it says, and probably will only leave a FileSystem::new method which also takes a scrubber.

I haven't found a way to transform Box<dyn Database> to Box<dyn IterableDatabase>, but if it is possible, then this PR is not needed.