### PR TITLE
Implement FuseFS — wrap around FileSystem that implements fuser::Filesystem trait to mount it. 

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,13 +12,23 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+
+      - name: Install FUSE dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y fuse3 libfuse3-dev
+
       - name: Formatting
         run: cargo fmt -- --check
+
       - name: Clippy
         run: cargo clippy --all-targets --tests -- -D warnings
+
       - name: Build
         run: cargo build --all-features --all-targets --verbose
+
       - name: Run tests
         run: cargo test --verbose
+
       - name: Run binary
         run: cargo build -p chunkfscli --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,6 +17,7 @@ jobs:
         run: |
           sudo apt update
           sudo apt install -y fuse3 libfuse3-dev
+          echo "user_allow_other" | sudo tee -a /etc/fuse.conf
 
       - name: Formatting
         run: cargo fmt -- --check

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -188,6 +188,7 @@ dependencies = [
  "criterion",
  "csv",
  "fastcdc",
+ "filetime",
  "fuser",
  "itertools 0.14.0",
  "libc",
@@ -490,6 +491,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "filetime"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+ "windows-sys",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -707,6 +720,17 @@ name = "libm"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
+
+[[package]]
+name = "libredox"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+dependencies = [
+ "bitflags",
+ "libc",
+ "redox_syscall",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -937,6 +961,15 @@ checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,6 +157,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -182,7 +188,9 @@ dependencies = [
  "criterion",
  "csv",
  "fastcdc",
+ "fuser",
  "itertools 0.14.0",
+ "libc",
  "rand 0.9.0",
  "serde",
  "serde_json",
@@ -488,6 +496,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "fuser"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53274f494609e77794b627b1a3cddfe45d675a6b2e9ba9c0fdc8d8eee2184369"
+dependencies = [
+ "libc",
+ "log",
+ "memchr",
+ "nix",
+ "page_size",
+ "pkg-config",
+ "smallvec",
+ "zerocopy",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -703,6 +727,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -729,6 +765,22 @@ name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plotters"
@@ -1049,6 +1101,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "smallvec"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1281,6 +1339,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1288,6 +1362,12 @@ checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
  "windows-sys",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,6 +192,7 @@ dependencies = [
  "fuser",
  "itertools 0.14.0",
  "libc",
+ "nix 0.30.1",
  "rand 0.9.0",
  "serde",
  "serde_json",
@@ -517,7 +518,7 @@ dependencies = [
  "libc",
  "log",
  "memchr",
- "nix",
+ "nix 0.29.0",
  "page_size",
  "pkg-config",
  "smallvec",
@@ -755,6 +756,18 @@ name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
  "bitflags",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,8 @@ csv = { version = "1", optional = true }
 serde = { version = "1", optional = true, features = ["derive"] }
 serde_with = { version = "3", optional = true }
 chrono = { version = "0.4", optional = true, features = ["serde"] }
+libc = "0.2.171"
+fuser = "0.15.1"
 
 [features]
 chunkers = ["cdc-chunkers", "fastcdc"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ serde = { version = "1", optional = true, features = ["derive"] }
 serde_with = { version = "3", optional = true }
 chrono = { version = "0.4", optional = true, features = ["serde"] }
 libc = "0.2.171"
-fuser = "0.15.1"
+fuser = { version = "0.15.1", features = ["abi-7-28"] }
 
 [features]
 chunkers = ["cdc-chunkers", "fastcdc"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ criterion = "0.5"
 sha3 = "0.10"
 approx = "0.5"
 tempfile = "3.14"
+filetime = "0.2.25"
 
 serde_json = "1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ serde_with = { version = "3", optional = true }
 chrono = { version = "0.4", optional = true, features = ["serde"] }
 libc = "0.2.171"
 fuser = { version = "0.15.1", features = ["abi-7-28"] }
+nix = { version = "0.30.1", features = ["ioctl"] }
 
 [features]
 chunkers = ["cdc-chunkers", "fastcdc"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,3 +53,7 @@ harness = false
 [[bench]]
 name = "chunker_sizes"
 harness = false
+
+[[bench]]
+name = "fuse_write_read"
+harness = false

--- a/README.md
+++ b/README.md
@@ -82,6 +82,21 @@ To use provided chunkers and hashers, use the corresponding features:
 chunkfs = { version = "0.1", features = ["chunkers", "hashers"] }
 ```
 
+## FUSE native dependepcies
+
+To use FuseFS structure, mountable with FUSE, you need to install the following native dependencies:
+
+```bash
+sudo apt update
+sudo apt install -y fuse3 libfuse3-dev
+```
+
+To use the file system correctly, you need to allow other users to access the mounted file system.
+
+```bash
+echo "user_allow_other" | sudo tee -a /etc/fuse.conf
+```
+
 ## Examples
 
 Examples for chunkfs usage and benching are provided in [examples](examples) folder.

--- a/benches/chunker_sizes.rs
+++ b/benches/chunker_sizes.rs
@@ -54,8 +54,8 @@ fn get_chunker(algorithm: Algorithms, params: SizeParams) -> ChunkerRef {
     match algorithm {
         Algorithms::Rabin => RabinChunker::new(params).into(),
         Algorithms::Leap => LeapChunker::new(params).into(),
-        Algorithms::Super => UltraChunker::new(params).into(),
-        Algorithms::Ultra => SuperChunker::new(params).into(),
+        Algorithms::Super => SuperChunker::new(params).into(),
+        Algorithms::Ultra => UltraChunker::new(params).into(),
     }
 }
 

--- a/benches/fuse_write_read.rs
+++ b/benches/fuse_write_read.rs
@@ -41,8 +41,8 @@ fn get_chunker(algorithm: Algorithms, params: SizeParams) -> ChunkerRef {
     match algorithm {
         Algorithms::Rabin => RabinChunker::new(params).into(),
         Algorithms::Leap => LeapChunker::new(params).into(),
-        Algorithms::Super => UltraChunker::new(params).into(),
-        Algorithms::Ultra => SuperChunker::new(params).into(),
+        Algorithms::Super => SuperChunker::new(params).into(),
+        Algorithms::Ultra => UltraChunker::new(params).into(),
     }
 }
 

--- a/benches/fuse_write_read.rs
+++ b/benches/fuse_write_read.rs
@@ -1,0 +1,197 @@
+use cdc_chunkers::SizeParams;
+use chunkfs::chunkers::{LeapChunker, RabinChunker, SuperChunker, UltraChunker};
+use chunkfs::hashers::Sha256Hasher;
+use chunkfs::{ChunkerRef, FuseFS, MB};
+use criterion::measurement::WallTime;
+use criterion::{BatchSize, BenchmarkGroup, BenchmarkId, Criterion, Throughput};
+use fuser::MountOption::AutoUnmount;
+use std::collections::HashMap;
+use std::fs;
+use std::fs::{File, OpenOptions};
+use std::io::{Read, Write};
+use std::path::Path;
+
+const SAMPLE_SIZE: usize = 30;
+
+#[allow(dead_code)]
+#[derive(Copy, Clone, Debug)]
+enum Algorithms {
+    Rabin,
+    Leap,
+    Super,
+    Ultra,
+}
+
+#[allow(dead_code)]
+fn chunkers() -> Vec<Algorithms> {
+    vec![
+        Algorithms::Rabin,
+        Algorithms::Leap,
+        Algorithms::Super,
+        Algorithms::Ultra,
+    ]
+}
+
+#[allow(dead_code)]
+fn get_chunker(algorithm: Algorithms, params: SizeParams) -> ChunkerRef {
+    match algorithm {
+        Algorithms::Rabin => RabinChunker::new(params).into(),
+        Algorithms::Leap => LeapChunker::new(params).into(),
+        Algorithms::Super => UltraChunker::new(params).into(),
+        Algorithms::Ultra => SuperChunker::new(params).into(),
+    }
+}
+
+#[allow(dead_code)]
+fn get_default_sizes(algorithm: Algorithms) -> SizeParams {
+    match algorithm {
+        Algorithms::Rabin => SizeParams::rabin_default(),
+        Algorithms::Leap => SizeParams::leap_default(),
+        Algorithms::Super => SizeParams::super_default(),
+        Algorithms::Ultra => SizeParams::ultra_default(),
+    }
+}
+
+struct Dataset {
+    filename: String,
+    size: u64,
+}
+
+pub fn bench(c: &mut Criterion) {
+    let dataset1_len = File::open("archX4.tar").unwrap().metadata().unwrap().len();
+    let dataset1 = Dataset {
+        filename: "archX4.tar".to_string(),
+        size: dataset1_len,
+    };
+    let datasets = vec![dataset1];
+
+    for dataset in datasets {
+        let mut group = c.benchmark_group("FuseChunkers");
+        group.sample_size(SAMPLE_SIZE);
+        group.throughput(Throughput::Bytes(dataset.size));
+
+        for chunker in chunkers() {
+            let params = get_default_sizes(chunker);
+            bench_write(&dataset, &mut group, chunker, params);
+        }
+
+        for chunker in chunkers() {
+            let params = get_default_sizes(chunker);
+            bench_read(&dataset, &mut group, chunker, params);
+        }
+    }
+}
+
+fn bench_write(
+    dataset: &Dataset,
+    group: &mut BenchmarkGroup<WallTime>,
+    algorithm: Algorithms,
+    params: SizeParams,
+) {
+    let bench_name = dataset.filename.clone();
+    let parameter = format!("write_fuse-{:?}-{}", algorithm, params);
+    group.bench_function(BenchmarkId::new(bench_name, parameter), |b| {
+        b.iter_batched(
+            || {
+                let mount_point = Path::new("mount_dir/mount_point");
+                let db = HashMap::default();
+                let chunker = get_chunker(algorithm, params);
+                let fuse_fs = FuseFS::new(db, Sha256Hasher::default(), chunker);
+
+                fs::create_dir_all(mount_point).unwrap();
+                let session = fuser::spawn_mount2(fuse_fs, mount_point, &[AutoUnmount]).unwrap();
+
+                let fuse_path = mount_point.join("file");
+                let fuse_file = OpenOptions::new()
+                    .write(true)
+                    .read(true)
+                    .create(true)
+                    .truncate(true)
+                    .open(&fuse_path)
+                    .unwrap();
+
+                let source = File::open(&dataset.filename).unwrap();
+
+                (session, source, fuse_file)
+            },
+            |(_session, mut source, mut fuse_file)| {
+                let mut buf = vec![0; 50 * MB];
+                loop {
+                    let bytes_read = source.read(&mut buf).unwrap();
+                    if bytes_read == 0 {
+                        break;
+                    }
+                    fuse_file.write_all(&buf[..bytes_read]).unwrap();
+                }
+                drop(fuse_file);
+            },
+            BatchSize::PerIteration,
+        )
+    });
+}
+
+fn bench_read(
+    dataset: &Dataset,
+    group: &mut BenchmarkGroup<WallTime>,
+    algorithm: Algorithms,
+    params: SizeParams,
+) {
+    let mount_point = Path::new("mount_dir/mount_point");
+    let db = HashMap::default();
+    let chunker = get_chunker(algorithm, params);
+    let fuse_fs = FuseFS::new(db, Sha256Hasher::default(), chunker);
+
+    fs::create_dir_all(mount_point).unwrap();
+    let _session = fuser::spawn_mount2(fuse_fs, mount_point, &[AutoUnmount]).unwrap();
+
+    let fuse_path = mount_point.join("file");
+    let mut fuse_file = OpenOptions::new()
+        .write(true)
+        .read(true)
+        .create(true)
+        .truncate(true)
+        .open(&fuse_path)
+        .unwrap();
+
+    let mut source = File::open(&dataset.filename).unwrap();
+
+    let mut buf = vec![0; 50 * MB];
+    loop {
+        let bytes_read = source.read(&mut buf).unwrap();
+        if bytes_read == 0 {
+            break;
+        }
+        fuse_file.write_all(&buf[..bytes_read]).unwrap();
+    }
+    fuse_file.flush().unwrap();
+    drop(fuse_file);
+
+    let bench_name = dataset.filename.clone();
+    let parameter = format!("read_fuse-{:?}-{}", algorithm, params);
+    group.bench_function(BenchmarkId::new(bench_name, parameter), |b| {
+        b.iter_batched(
+            || File::open(&fuse_path).unwrap(),
+            |mut fuse_file| {
+                let mut buf = vec![0; 50 * MB];
+                loop {
+                    let bytes_read = fuse_file.read(&mut buf).unwrap();
+                    if bytes_read == 0 {
+                        break;
+                    }
+                }
+            },
+            BatchSize::PerIteration,
+        )
+    });
+}
+
+pub fn benches() {
+    let mut criterion: Criterion<_> = Criterion::default().configure_from_args();
+    bench(&mut criterion);
+}
+
+fn main() {
+    benches();
+
+    Criterion::default().configure_from_args().final_summary();
+}

--- a/benches/write_read.rs
+++ b/benches/write_read.rs
@@ -33,8 +33,8 @@ fn get_chunker(algorithm: Algorithms) -> ChunkerRef {
     match algorithm {
         Algorithms::Rabin => RabinChunker::default().into(),
         Algorithms::Leap => LeapChunker::default().into(),
-        Algorithms::Super => UltraChunker::default().into(),
-        Algorithms::Ultra => SuperChunker::default().into(),
+        Algorithms::Super => SuperChunker::default().into(),
+        Algorithms::Ultra => UltraChunker::default().into(),
     }
 }
 

--- a/examples/mount.rs
+++ b/examples/mount.rs
@@ -1,0 +1,46 @@
+use chunkfs::chunkers::SuperChunker;
+use chunkfs::hashers::SimpleHasher;
+use chunkfs::{FuseFS, MB};
+use std::collections::HashMap;
+use std::fs;
+use std::fs::OpenOptions;
+use std::io::{Read, Seek, SeekFrom, Write};
+use std::os::unix::fs::FileExt;
+
+const MOUNT_POINT: &str = "./mount_point";
+
+fn main() {
+    let db = HashMap::default();
+    let fuse_fs = FuseFS::new(db, SimpleHasher, SuperChunker::default());
+
+    fs::create_dir_all(MOUNT_POINT).unwrap();
+
+    let session = fuser::spawn_mount2(fuse_fs, MOUNT_POINT, &vec![]).unwrap();
+
+    let file_path = format!("{}/{}", MOUNT_POINT, "file");
+    // careful: writing is sequential only
+    let mut file = OpenOptions::new()
+        .write(true)
+        .read(true)
+        .create(true)
+        .open(&file_path)
+        .unwrap();
+
+    let data1 = vec![1u8; 2 * MB];
+    let data2 = vec![2u8; 5 * MB];
+    file.write_all(&data1).unwrap();
+    file.write_all(&data2).unwrap();
+
+    let expected: Vec<u8> = vec![1, 1, 1, 1, 2, 2, 2];
+    let mut actual = vec![0u8; expected.len()];
+    file.read_exact_at(&mut actual, 2 * MB as u64 - 4).unwrap();
+    assert_eq!(expected, actual);
+
+    file.seek(SeekFrom::Start(0)).unwrap();
+    let mut file_data = vec![0u8; 7 * MB];
+    let read_size = file.read_to_end(&mut file_data).unwrap();
+    assert_eq!(read_size, 7 * MB);
+
+    drop(session);
+    fs::remove_dir_all(MOUNT_POINT).unwrap();
+}

--- a/examples/mount.rs
+++ b/examples/mount.rs
@@ -15,7 +15,7 @@ fn main() {
 
     fs::create_dir_all(mount_point).unwrap();
 
-    let session = fuser::spawn_mount2(fuse_fs, mount_point, &vec![]).unwrap();
+    let session = fuser::spawn_mount2(fuse_fs, mount_point, &[]).unwrap();
 
     let file_path = mount_point.join("file");
     // careful: writing is sequential only
@@ -23,6 +23,7 @@ fn main() {
         .write(true)
         .read(true)
         .create(true)
+        .truncate(true)
         .open(&file_path)
         .unwrap();
 

--- a/examples/mount.rs
+++ b/examples/mount.rs
@@ -6,18 +6,18 @@ use std::fs;
 use std::fs::OpenOptions;
 use std::io::{Read, Seek, SeekFrom, Write};
 use std::os::unix::fs::FileExt;
-
-const MOUNT_POINT: &str = "./mount_point";
+use std::path::Path;
 
 fn main() {
+    let mount_point = Path::new("./mount_point");
     let db = HashMap::default();
     let fuse_fs = FuseFS::new(db, SimpleHasher, SuperChunker::default());
 
-    fs::create_dir_all(MOUNT_POINT).unwrap();
+    fs::create_dir_all(mount_point).unwrap();
 
-    let session = fuser::spawn_mount2(fuse_fs, MOUNT_POINT, &vec![]).unwrap();
+    let session = fuser::spawn_mount2(fuse_fs, mount_point, &vec![]).unwrap();
 
-    let file_path = format!("{}/{}", MOUNT_POINT, "file");
+    let file_path = mount_point.join("file");
     // careful: writing is sequential only
     let mut file = OpenOptions::new()
         .write(true)
@@ -42,5 +42,5 @@ fn main() {
     assert_eq!(read_size, 7 * MB);
 
     drop(session);
-    fs::remove_dir_all(MOUNT_POINT).unwrap();
+    fs::remove_dir_all(mount_point).unwrap();
 }

--- a/examples/mount.rs
+++ b/examples/mount.rs
@@ -1,6 +1,7 @@
 use chunkfs::chunkers::SuperChunker;
 use chunkfs::hashers::SimpleHasher;
 use chunkfs::{FuseFS, MB};
+use fuser::MountOption::AutoUnmount;
 use std::collections::HashMap;
 use std::fs;
 use std::fs::OpenOptions;
@@ -15,7 +16,7 @@ fn main() {
 
     fs::create_dir_all(mount_point).unwrap();
 
-    let session = fuser::spawn_mount2(fuse_fs, mount_point, &[]).unwrap();
+    let session = fuser::spawn_mount2(fuse_fs, mount_point, &[AutoUnmount]).unwrap();
 
     let file_path = mount_point.join("file");
     // careful: writing is sequential only

--- a/src/bench/mod.rs
+++ b/src/bench/mod.rs
@@ -257,7 +257,7 @@ where
         let mut buffer = Vec::with_capacity(MB);
 
         loop {
-            let read = self.fs.read_1mb_from_file(&mut fs_file)?;
+            let read = self.fs.read_from_file(&mut fs_file)?;
             if read.is_empty() {
                 break;
             }

--- a/src/bench/mod.rs
+++ b/src/bench/mod.rs
@@ -257,7 +257,7 @@ where
         let mut buffer = Vec::with_capacity(MB);
 
         loop {
-            let read = self.fs.read_from_file(&mut fs_file)?;
+            let read = self.fs.read_1mb_from_file(&mut fs_file)?;
             if read.is_empty() {
                 break;
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 pub use system::database::{Database, IterableDatabase};
-pub use system::fuse_filesystem::FuseFS;
+pub use system::fuse_filesystem::{FuseFS, IOC_GET_AVG_CHUNK_SIZE, IOC_GET_DEDUP_RATIO};
 pub use system::scrub::{CopyScrubber, Scrub, ScrubMeasurements};
 pub use system::storage::{Data, DataContainer};
 pub use system::{create_cdc_filesystem, FileSystem};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,14 +73,14 @@ impl Chunk {
 /// If some contents were cut because the end of `data` and not the end of the chunk was reached,
 /// it must be returned with [`rest`][Chunker::rest] instead of storing it in the [`chunk_data`][Chunker::chunk_data]'s output.
 pub trait Chunker: Debug + Send {
-    /// Goes through whole `data` and finds chunks. If last chunk is not actually a chunk but a leftover,
+    /// Goes through whole `data` and finds chunks. If the last chunk is not actually a chunk but a leftover,
     /// it is returned via [`rest`][Chunker::rest] method and is not contained in the vector.
     ///
     /// `empty` is an empty vector whose capacity is determined by [`estimate_chunk_count`][Chunker::estimate_chunk_count].
-    /// Resulting chunks should be written right to it, and it should be returned as result.
+    /// Resulting chunks should be written right to it, and it should be returned as a result.
     fn chunk_data(&mut self, data: &[u8], empty: Vec<Chunk>) -> Vec<Chunk>;
 
-    /// Returns an estimate amount of chunks that will be created once the algorithm runs through the whole
+    /// Returns an estimate number of chunks that will be created once the algorithm runs through the whole
     /// data buffer. Used to pre-allocate the buffer with the required size so that allocation times are not counted
     /// towards total chunking time.
     fn estimate_chunk_count(&self, data: &[u8]) -> usize;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 pub use system::database::{Database, IterableDatabase};
+pub use system::fuse_filesystem::FuseFS;
 pub use system::scrub::{CopyScrubber, Scrub, ScrubMeasurements};
 pub use system::storage::{Data, DataContainer};
 pub use system::{create_cdc_filesystem, FileSystem};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,7 @@ impl Chunk {
 /// Chunks that are found are returned by [`chunk_data`][Chunker::chunk_data] method.
 /// If some contents were cut because the end of `data` and not the end of the chunk was reached,
 /// it must be returned with [`rest`][Chunker::rest] instead of storing it in the [`chunk_data`][Chunker::chunk_data]'s output.
-pub trait Chunker: Debug {
+pub trait Chunker: Debug + Send {
     /// Goes through whole `data` and finds chunks. If last chunk is not actually a chunk but a leftover,
     /// it is returned via [`rest`][Chunker::rest] method and is not contained in the vector.
     ///
@@ -126,7 +126,7 @@ impl Debug for ChunkerRef {
 }
 
 /// Functionality for an object that hashes the input.
-pub trait Hasher {
+pub trait Hasher: Send {
     /// Hash type that would be returned by the hasher.
     type Hash: ChunkHash;
 

--- a/src/system/database.rs
+++ b/src/system/database.rs
@@ -27,7 +27,7 @@ pub trait Database<K, V> {
     }
 
     /// Retrieves a multitude of values, corresponding to the keys, in the correct order.
-    fn get_multi(&self, keys: &[K]) -> io::Result<Vec<V>> {
+    fn get_multi(&self, keys: Vec<&K>) -> io::Result<Vec<V>> {
         keys.iter().map(|key| self.get(key)).collect()
     }
 

--- a/src/system/database.rs
+++ b/src/system/database.rs
@@ -14,7 +14,7 @@ pub trait Database<K, V> {
     /// Retrieves a value by a given key. Note that it returns a value, not a reference.
     ///
     /// # Errors
-    /// Should return [ErrorKind::NotFound], if the key-value pair
+    /// Should return [ErrorKind::NotFound] if the key-value pair
     /// was not found in the storage.
     fn get(&self, key: &K) -> io::Result<V>;
 

--- a/src/system/database.rs
+++ b/src/system/database.rs
@@ -27,7 +27,7 @@ pub trait Database<K, V> {
     }
 
     /// Retrieves a multitude of values, corresponding to the keys, in the correct order.
-    fn get_multi(&self, keys: Vec<&K>) -> io::Result<Vec<V>> {
+    fn get_multi(&self, keys: &[&K]) -> io::Result<Vec<V>> {
         keys.iter().map(|key| self.get(key)).collect()
     }
 

--- a/src/system/file_layer.rs
+++ b/src/system/file_layer.rs
@@ -226,7 +226,7 @@ impl<Hash: ChunkHash> FileLayer<Hash> {
     }
 
     #[cfg(feature = "bench")]
-    /// Generate a new dataset with 
+    /// Generate a new dataset with
     /// a set deduplication ratio from the existing one.
     ///
     /// Returns the name of the new file.

--- a/src/system/file_layer.rs
+++ b/src/system/file_layer.rs
@@ -187,6 +187,7 @@ impl<Hash: ChunkHash> FileLayer<Hash> {
         if spans.is_empty() {
             return spans;
         }
+
         let last_span = spans.last().unwrap();
         let read_size_possible = last_span.offset + last_span.len - handle.offset;
         handle.offset += min(read_size_possible, size);

--- a/src/system/file_layer.rs
+++ b/src/system/file_layer.rs
@@ -98,7 +98,7 @@ impl FileHandle {
         &self.file_name
     }
 
-    /// Closes handle and returns [`WriteMeasurements`] made while file was open.
+    /// Closes the handle and returns [`WriteMeasurements`] made while a file was open.
     pub(crate) fn close(self) -> WriteMeasurements {
         self.measurements
     }
@@ -170,8 +170,8 @@ impl<Hash: ChunkHash> FileLayer<Hash> {
     }
 
     /// Reads the specified amount of data from the open file and
-    /// returns FileSpans in which the necessary data is stored (the side FileSpans may contain it partially).
-    /// Starting point is based on the `FileHandle`'s offset.
+    /// returns FileSpans, in which the necessary data is stored (the side FileSpans may contain it partially).
+    /// The Starting point is based on the `FileHandle`'s offset.
     ///
     /// If `size` + file handle offset is greater than file size, then returns FileSpans up to the end of the file.
     pub fn read(&self, handle: &mut FileHandle, size: usize) -> Vec<&FileSpan<Hash>> {
@@ -226,7 +226,8 @@ impl<Hash: ChunkHash> FileLayer<Hash> {
     }
 
     #[cfg(feature = "bench")]
-    /// Generate a new dataset with set deduplication ratio from the existing one.
+    /// Generate a new dataset with 
+    /// a set deduplication ratio from the existing one.
     ///
     /// Returns the name of the new file.
     pub fn get_to_dedup_ratio(&mut self, name: &str, dedup_ratio: f64) -> io::Result<String> {

--- a/src/system/file_layer.rs
+++ b/src/system/file_layer.rs
@@ -21,12 +21,12 @@ impl<Hash: ChunkHash> FileSpan<Hash> {
         &self.hash
     }
 
-    pub fn offset(&self) -> &usize {
-        &self.offset
+    pub fn offset(&self) -> usize {
+        self.offset.clone()
     }
 
-    pub fn len(&self) -> &usize {
-        &self.len
+    pub fn len(&self) -> usize {
+        self.len.clone()
     }
 }
 

--- a/src/system/file_layer.rs
+++ b/src/system/file_layer.rs
@@ -88,16 +88,9 @@ impl FileHandle {
         self.offset.clone()
     }
 
-    /// Sets the offset for the read-only file handle.
-    pub fn set_offset(&mut self, offset: usize) -> io::Result<()> {
-        if self.chunker.is_some() {
-            return Err(io::Error::new(
-                ErrorKind::PermissionDenied,
-                "offset can only be set with read-only file handles",
-            ));
-        }
+    /// Sets the offset for the file handle.
+    pub fn set_offset(&mut self, offset: usize) {
         self.offset = offset;
-        Ok(())
     }
 
     /// Returns name of the file.

--- a/src/system/file_layer.rs
+++ b/src/system/file_layer.rs
@@ -22,11 +22,11 @@ impl<Hash: ChunkHash> FileSpan<Hash> {
     }
 
     pub fn offset(&self) -> usize {
-        self.offset.clone()
+        self.offset
     }
 
     pub fn len(&self) -> usize {
-        self.len.clone()
+        self.len
     }
 }
 
@@ -85,7 +85,7 @@ impl FileHandle {
     }
 
     pub fn offset(&self) -> usize {
-        self.offset.clone()
+        self.offset
     }
 
     /// Sets the offset for the file handle.

--- a/src/system/file_layer.rs
+++ b/src/system/file_layer.rs
@@ -84,8 +84,8 @@ impl FileHandle {
         }
     }
 
-    pub fn offset(&self) -> &usize {
-        &self.offset
+    pub fn offset(&self) -> usize {
+        self.offset.clone()
     }
 
     /// Sets the offset for the read-only file handle.

--- a/src/system/fuse_filesystem.rs
+++ b/src/system/fuse_filesystem.rs
@@ -218,7 +218,7 @@ where
         Ok(())
     }
 
-    fn lookup(&mut self, _req: &Request<'_>, parent: u64, name: &OsStr, reply: ReplyEntry) {
+    fn lookup(&mut self, req: &Request<'_>, parent: u64, name: &OsStr, reply: ReplyEntry) {
         let name = name.to_str().unwrap().to_owned();
         if parent != 1 {
             reply.error(libc::EINVAL);
@@ -229,6 +229,12 @@ where
             reply.error(libc::ENOENT);
             return;
         };
+        let parent_attr = self.files.get(&parent).unwrap().attr;
+        if !check_access(&parent_attr, req, libc::X_OK) {
+            reply.error(libc::EACCES);
+            return;
+        }
+
         let file = self.files.get(inode).unwrap();
         reply.entry(&Duration::new(0, 0), &file.attr, file.generation)
     }

--- a/src/system/fuse_filesystem.rs
+++ b/src/system/fuse_filesystem.rs
@@ -191,6 +191,9 @@ where
                 .files
                 .get_mut(&handle.inode)
                 .ok_or(io::ErrorKind::NotFound)?;
+            handle
+                .underlying_file_handle
+                .set_offset(file.attr.size as usize - file.cache.len());
             self.underlying_fs
                 .write_to_file(&mut handle.underlying_file_handle, &file.cache)?;
 

--- a/src/system/fuse_filesystem.rs
+++ b/src/system/fuse_filesystem.rs
@@ -346,7 +346,7 @@ where
         // file_handle.underlying_file_handle.offset = offset;
         let Ok(_data) = self
             .underlying_fs
-            .read_from_file(&mut file_handle.underlying_file_handle)
+            .read_1mb_from_file(&mut file_handle.underlying_file_handle)
         else {
             reply.error(EIO);
             return;

--- a/src/system/fuse_filesystem.rs
+++ b/src/system/fuse_filesystem.rs
@@ -20,9 +20,9 @@ use std::time::{Duration, SystemTime};
 /// The File is opened for execution.
 const FMODE_EXEC: i32 = 0x20;
 /// Total cache size of all files, after which all caches will be [`dropped and shrank`][FuseFS::drop_and_shrink_cache] to the [`underlying filesystem`][FileSystem].
-const FILESYSTEM_CACHE_MAX_SIZE: usize = 25 * MB;
+const FILESYSTEM_CACHE_MAX_SIZE: usize = 250 * MB;
 /// Maximum cache size, after which it will drop [`dropped and shrank`][FuseFS::drop_and_shrink_cache] to the [`underlying filesystem`][FileSystem].
-const FILE_CACHE_MAX_SIZE: usize = 5 * MB;
+const FILE_CACHE_MAX_SIZE: usize = 100 * MB;
 
 /// Command number for filesystem dedup ratio request via ioctl.
 pub const IOC_GET_DEDUP_RATIO: u64 = nix::request_code_read!('S', 0, size_of::<f64>());

--- a/src/system/fuse_filesystem.rs
+++ b/src/system/fuse_filesystem.rs
@@ -218,7 +218,14 @@ where
         Ok(())
     }
 
-    fn flush(&mut self, _req: &Request<'_>, ino: u64, fh: u64, lock_owner: u64, reply: ReplyEmpty) {
+    fn flush(
+        &mut self,
+        _req: &Request<'_>,
+        ino: u64,
+        fh: u64,
+        _lock_owner: u64,
+        reply: ReplyEmpty,
+    ) {
         let Some(file_handle) = self.file_handles.get_mut(&fh) else {
             reply.error(libc::EBADF);
             return;

--- a/src/system/fuse_filesystem.rs
+++ b/src/system/fuse_filesystem.rs
@@ -37,8 +37,6 @@ struct FuseFile {
     attr: FileAttr,
     /// File name.
     name: String,
-    /// Generation of a file. Increments every time the file content is modified.
-    generation: u64,
     /// Number of opened file handles.
     handles: u64,
 }
@@ -118,7 +116,6 @@ where
             cache: Vec::new(),
             attr: root_attr,
             name: ".".to_string(),
-            generation: 0,
             handles: 0,
         };
         let mut parent_dir = root_dir.clone();
@@ -265,7 +262,7 @@ where
         }
 
         let file = self.files.get(inode).unwrap();
-        reply.entry(&Duration::new(0, 0), &file.attr, file.generation)
+        reply.entry(&Duration::new(0, 0), &file.attr, 0)
     }
 
     fn getattr(&mut self, _req: &Request<'_>, ino: u64, _fh: Option<u64>, reply: ReplyAttr) {
@@ -530,7 +527,6 @@ where
         let file = self.files.get_mut(&ino).unwrap();
         file.attr.ctime = now;
         file.attr.mtime = now;
-        file.generation += 1;
 
         reply.written(data.len() as u32);
     }
@@ -701,7 +697,6 @@ where
             cache: Vec::new(),
             attr,
             name: name.clone(),
-            generation: 0,
             handles: 1,
         };
 

--- a/src/system/fuse_filesystem.rs
+++ b/src/system/fuse_filesystem.rs
@@ -701,10 +701,10 @@ where
         };
 
         let fh = self.get_new_fh();
-        reply.created(&Duration::new(0, 0), &file.attr, 0, fh, flags as u32);
-
-        self.files.insert(ino, file);
+        self.files.insert(ino, file.clone());
         self.inodes.insert(name, ino);
         self.file_handles.insert(fh, file_handle);
+
+        reply.created(&Duration::new(0, 0), &file.attr, 0, fh, flags as u32);
     }
 }

--- a/src/system/fuse_filesystem.rs
+++ b/src/system/fuse_filesystem.rs
@@ -511,9 +511,13 @@ where
             reply.error(libc::EACCES);
             return;
         }
-
+        
+        let cache_cap_before = file.cache.capacity();
         file.cache.extend_from_slice(data);
+        let cache_cap_after = file.cache.capacity();
+        self.total_cache += cache_cap_after - cache_cap_before;
         file.attr.size += data.len() as u64;
+        
         if file.cache.len() > FILE_CACHE_MAX_SIZE && self.drop_cache(ino, fh).is_err() {
             reply.error(libc::EIO);
             return;

--- a/src/system/fuse_filesystem.rs
+++ b/src/system/fuse_filesystem.rs
@@ -385,7 +385,7 @@ where
             return;
         }
 
-        if !check_access(&file.attr, req, libc::R_OK) || !file_handle.write {
+        if !check_access(&file.attr, req, libc::W_OK) || !file_handle.write {
             reply.error(libc::EACCES);
             return;
         }

--- a/src/system/fuse_filesystem.rs
+++ b/src/system/fuse_filesystem.rs
@@ -347,19 +347,10 @@ where
             reply.error(EACCES);
             return;
         }
-        if file_handle
-            .underlying_file_handle
-            .set_offset(offset as usize)
-            .is_err()
-        {
-            reply.error(EACCES);
-            return;
-        };
+        let underlying_fh = &mut file_handle.underlying_file_handle;
+        underlying_fh.set_offset(offset as usize);
 
-        if let Ok(data) = self
-            .underlying_fs
-            .read(&mut file_handle.underlying_file_handle, size as usize)
-        {
+        if let Ok(data) = self.underlying_fs.read(underlying_fh, size as usize) {
             reply.data(&data);
             return;
         } else {

--- a/src/system/fuse_filesystem.rs
+++ b/src/system/fuse_filesystem.rs
@@ -19,8 +19,8 @@ type Fh = u64;
 
 /// File is opened for execution.
 const FMODE_EXEC: i32 = 0x20;
-const FILESYSTEM_CACHE_MAX_SIZE: usize = 500 * MB;
-const FILE_CACHE_MAX_SIZE: usize = 200 * MB;
+const FILESYSTEM_CACHE_MAX_SIZE: usize = 25 * MB;
+const FILE_CACHE_MAX_SIZE: usize = 5 * MB;
 
 #[derive(Clone)]
 struct FuseFile {

--- a/src/system/fuse_filesystem.rs
+++ b/src/system/fuse_filesystem.rs
@@ -36,6 +36,9 @@ struct FuseFileHandle {
     inode: u64,
 }
 
+/// Wrap around [`FileSystem`] for implementing [`fuser::Filesystem`] trait.
+///
+/// After creation, it should be passed to [`mount2`][fuser::mount2] or [`spawn_mount2`][fuser::spawn_mount2].
 pub struct FuseFS<B, Hash>
 where
     B: Database<Hash, DataContainer<()>>,
@@ -44,6 +47,7 @@ where
     underlying_fs: FileSystem<B, Hash, (), HashMap<(), Vec<u8>>>,
     files: HashMap<Inode, FuseFile>,
     inodes: HashMap<String, Inode>,
+    /// Number for the next created file handle.
     next_fh: u64,
     file_handles: HashMap<Fh, FuseFileHandle>,
     chunker: ChunkerRef,
@@ -54,6 +58,9 @@ where
     B: Database<Hash, DataContainer<()>>,
     Hash: ChunkHash,
 {
+    /// Creates a file system with the given [`hasher`][Hasher], [`database`][Database] and [`chunker`][ChunkerRef].
+    ///
+    /// After creation, it should be passed to [`mount2`][fuser::mount2] or [`spawn_mount2`][fuser::spawn_mount2].
     pub fn new<H, C>(base: B, hasher: H, chunker: C) -> Self
     where
         H: Into<Box<dyn Hasher<Hash = Hash> + 'static>>,
@@ -114,6 +121,7 @@ where
     }
 }
 
+/// Checks the request rights for the file with the specified access mask (flags).
 fn check_access(file_attr: &FileAttr, req: &Request, access_mask: i32) -> bool {
     let file_uid = file_attr.uid;
     let file_gid = file_attr.gid;

--- a/src/system/fuse_filesystem.rs
+++ b/src/system/fuse_filesystem.rs
@@ -338,7 +338,7 @@ where
             reply.error(libc::ESTALE);
             return;
         }
-        let Some(file) = self.files.get(&ino) else {
+        let Some(file) = self.files.get_mut(&ino) else {
             reply.error(libc::ENOENT);
             return;
         };
@@ -354,6 +354,9 @@ where
         let underlying_fh = &mut file_handle.underlying_file_handle;
         underlying_fh.set_offset(offset as usize);
 
+        let now = SystemTime::now();
+        file.attr.atime = now;
+        file.attr.ctime = now;
         if let Ok(data) = self.underlying_fs.read(underlying_fh, size as usize) {
             reply.data(&data);
             return;

--- a/src/system/fuse_filesystem.rs
+++ b/src/system/fuse_filesystem.rs
@@ -422,7 +422,7 @@ where
         &mut self,
         _req: &Request<'_>,
         ino: u64,
-        _fh: u64,
+        fh: u64,
         _flags: i32,
         _lock_owner: Option<u64>,
         _flush: bool,
@@ -436,7 +436,7 @@ where
             reply.error(libc::EINVAL);
             return;
         }
-        let Some(file_handle) = self.file_handles.remove(&ino) else {
+        let Some(file_handle) = self.file_handles.remove(&fh) else {
             reply.error(libc::EINVAL);
             return;
         };

--- a/src/system/fuse_filesystem.rs
+++ b/src/system/fuse_filesystem.rs
@@ -1,0 +1,549 @@
+use crate::system::file_layer::FileHandle;
+use crate::{
+    create_cdc_filesystem, ChunkHash, ChunkerRef, DataContainer, Database, FileSystem, Hasher,
+};
+use fuser::FileType::RegularFile;
+use fuser::TimeOrNow::Now;
+use fuser::{
+    FileAttr, FileType, Filesystem, ReplyAttr, ReplyCreate, ReplyData, ReplyDirectory, ReplyEmpty,
+    ReplyEntry, ReplyOpen, ReplyWrite, Request, TimeOrNow,
+};
+use libc::{
+    EACCES, EBADF, EEXIST, EINVAL, EIO, ENOENT, EPERM, ESTALE, O_ACCMODE, O_RDONLY, O_RDWR,
+    O_WRONLY, R_OK, W_OK, X_OK,
+};
+use std::cmp::min;
+use std::collections::HashMap;
+use std::ffi::OsStr;
+use std::time::{Duration, SystemTime};
+
+type Inode = u64;
+type Fh = u64;
+
+const FMODE_EXEC: i32 = 0x20;
+
+#[derive(Clone)]
+struct FuseFile {
+    attr: FileAttr,
+    name: String,
+    generation: u64,
+    handles: u64,
+}
+
+struct FuseFileHandle {
+    underlying_file_handle: FileHandle,
+    read: bool,
+    write: bool,
+    inode: u64,
+}
+
+pub struct FuseFS<B, Hash>
+where
+    B: Database<Hash, DataContainer<()>>,
+    Hash: ChunkHash,
+{
+    underlying_fs: FileSystem<B, Hash, (), HashMap<(), Vec<u8>>>,
+    files: HashMap<Inode, FuseFile>,
+    inodes: HashMap<String, Inode>,
+    next_fh: u64,
+    file_handles: HashMap<Fh, FuseFileHandle>,
+    chunker: ChunkerRef,
+}
+
+impl<B, Hash> FuseFS<B, Hash>
+where
+    B: Database<Hash, DataContainer<()>>,
+    Hash: ChunkHash,
+{
+    pub fn new<H, C>(base: B, hasher: H, chunker: C) -> Self
+    where
+        H: Into<Box<dyn Hasher<Hash = Hash> + 'static>>,
+        C: Into<ChunkerRef>,
+    {
+        let underlying_fs = create_cdc_filesystem(base, hasher);
+
+        let uid = unsafe { libc::getuid() };
+        let gid = unsafe { libc::getgid() };
+        let now = SystemTime::now();
+        let root_attr = FileAttr {
+            ino: 1,
+            size: 0,
+            blocks: 0,
+            atime: now,
+            mtime: now,
+            ctime: now,
+            crtime: now,
+            kind: FileType::Directory,
+            perm: 0o755,
+            nlink: 2,
+            uid,
+            gid,
+            rdev: 0,
+            flags: 0,
+            blksize: 512,
+        };
+        let root_dir = FuseFile {
+            attr: root_attr,
+            name: ".".to_string(),
+            generation: 0,
+            handles: 0,
+        };
+        let mut parent_dir = root_dir.clone();
+        parent_dir.name = "..".to_string();
+        parent_dir.attr.ino = 0;
+        let files = HashMap::from([(0, parent_dir), (1, root_dir)]);
+
+        let inodes = HashMap::from([("..".to_string(), 0), (".".to_string(), 1)]);
+        Self {
+            underlying_fs,
+            files,
+            inodes,
+            file_handles: HashMap::default(),
+            next_fh: 0,
+            chunker: chunker.into(),
+        }
+    }
+
+    fn get_new_inode(&self) -> Inode {
+        self.inodes.len() as Inode
+    }
+
+    fn get_new_fh(&mut self) -> Fh {
+        let next_fh = self.next_fh;
+        self.next_fh += 1;
+        next_fh
+    }
+}
+
+fn check_access(file_attr: &FileAttr, req: &Request, access_mask: i32) -> bool {
+    let file_uid = file_attr.uid;
+    let file_gid = file_attr.gid;
+    let file_mode = file_attr.perm;
+    let uid = req.uid();
+    let gid = req.gid();
+
+    let mut access_mask = access_mask;
+    // F_OK tests for existence of file
+    if access_mask == libc::F_OK {
+        return true;
+    }
+    let file_mode = i32::from(file_mode);
+
+    // root is allowed to read & write anything
+    if uid == 0 {
+        // root only allowed to exec if one of the Exec bits is set
+        access_mask &= X_OK;
+        access_mask -= access_mask & (file_mode >> 6);
+        access_mask -= access_mask & (file_mode >> 3);
+        access_mask -= access_mask & file_mode;
+        return access_mask == 0;
+    }
+
+    if uid == file_uid {
+        access_mask -= access_mask & (file_mode >> 6);
+    } else if gid == file_gid {
+        access_mask -= access_mask & (file_mode >> 3);
+    } else {
+        access_mask -= access_mask & file_mode;
+    }
+
+    access_mask == 0
+}
+
+impl<B, Hash> Filesystem for FuseFS<B, Hash>
+where
+    B: Database<Hash, DataContainer<()>>,
+    Hash: ChunkHash,
+{
+    fn lookup(&mut self, _req: &Request<'_>, parent: u64, name: &OsStr, reply: ReplyEntry) {
+        let name = name.to_str().unwrap().to_owned();
+        if parent != 1 {
+            reply.error(EINVAL);
+            return;
+        }
+
+        let Some(inode) = self.inodes.get::<String>(&name) else {
+            reply.error(ENOENT);
+            return;
+        };
+        let file = self.files.get(inode).unwrap();
+        reply.entry(&Duration::new(0, 0), &file.attr, file.generation)
+    }
+
+    fn getattr(&mut self, _req: &Request<'_>, ino: u64, _fh: Option<u64>, reply: ReplyAttr) {
+        match self.files.get(&ino) {
+            Some(file) => reply.attr(&Duration::new(0, 0), &file.attr),
+            None => reply.error(ENOENT),
+        }
+    }
+
+    fn setattr(
+        &mut self,
+        req: &Request<'_>,
+        ino: u64,
+        mode: Option<u32>,
+        _uid: Option<u32>,
+        _gid: Option<u32>,
+        _size: Option<u64>,
+        atime: Option<TimeOrNow>,
+        mtime: Option<TimeOrNow>,
+        _ctime: Option<SystemTime>,
+        _fh: Option<u64>,
+        _crtime: Option<SystemTime>,
+        _chgtime: Option<SystemTime>,
+        _bkuptime: Option<SystemTime>,
+        _flags: Option<u32>,
+        reply: ReplyAttr,
+    ) {
+        let Some(file) = self.files.get_mut(&ino) else {
+            reply.error(ENOENT);
+            return;
+        };
+
+        let now = SystemTime::now();
+        let attr = &mut file.attr;
+        if let Some(mode) = mode {
+            if req.uid() != 0 && req.uid() != attr.uid {
+                reply.error(EPERM);
+                return;
+            } else {
+                attr.perm = mode as u16;
+            }
+            attr.ctime = now;
+            reply.attr(&Duration::new(0, 0), &file.attr);
+            return;
+        }
+
+        if let Some(atime) = atime {
+            if attr.uid != req.uid() && req.uid() != 0 && atime != Now {
+                reply.error(EPERM);
+                return;
+            }
+
+            if attr.uid != req.uid() && !check_access(&attr, req, W_OK) {
+                reply.error(EACCES);
+                return;
+            }
+
+            attr.atime = match atime {
+                TimeOrNow::SpecificTime(time) => time,
+                Now => now,
+            };
+            attr.ctime = now;
+        }
+
+        if let Some(mtime) = mtime {
+            if attr.uid != req.uid() && req.uid() != 0 && mtime != Now {
+                reply.error(EPERM);
+                return;
+            }
+
+            if attr.uid != req.uid() && !check_access(&attr, req, W_OK) {
+                reply.error(EACCES);
+                return;
+            }
+
+            attr.mtime = match mtime {
+                TimeOrNow::SpecificTime(time) => time,
+                Now => now,
+            };
+            attr.ctime = now;
+        }
+
+        reply.attr(&Duration::new(0, 0), &attr);
+        return;
+    }
+
+    fn open(&mut self, req: &Request<'_>, ino: u64, flags: i32, reply: ReplyOpen) {
+        let Some(file) = self.files.get_mut(&ino) else {
+            reply.error(ENOENT);
+            return;
+        };
+
+        let (access_mask, read, write) = match flags & O_ACCMODE {
+            O_RDONLY => {
+                if flags & libc::O_TRUNC != 0 {
+                    reply.error(EACCES);
+                    return;
+                }
+                if flags & FMODE_EXEC != 0 {
+                    // Open is from internal exec syscall
+                    (X_OK, true, false)
+                } else {
+                    (R_OK, true, false)
+                }
+            }
+            O_WRONLY => (W_OK, false, true),
+            O_RDWR => (R_OK | W_OK, true, true),
+            // Exactly one access mode flag must be specified
+            _ => {
+                reply.error(EINVAL);
+                return;
+            }
+        };
+
+        if !check_access(&file.attr, req, access_mask) {
+            reply.error(EACCES);
+            return;
+        }
+
+        let underlying_file_handle = if write {
+            self.underlying_fs
+                .open_file(&file.name, self.chunker.clone())
+        } else {
+            self.underlying_fs.open_file_readonly(&file.name)
+        }
+        .unwrap();
+
+        let file_handle = FuseFileHandle {
+            underlying_file_handle,
+            inode: ino,
+            read,
+            write,
+        };
+        file.handles += 1;
+        let fh = self.get_new_fh();
+        self.file_handles.insert(fh, file_handle);
+
+        reply.opened(fh, flags as u32)
+    }
+
+    fn read(
+        &mut self,
+        req: &Request<'_>,
+        ino: u64,
+        fh: u64,
+        offset: i64,
+        size: u32,
+        _flags: i32,
+        _lock_owner: Option<u64>,
+        reply: ReplyData,
+    ) {
+        let Some(file_handle) = self.file_handles.get_mut(&fh) else {
+            reply.error(EBADF);
+            return;
+        };
+        if file_handle.inode != ino {
+            reply.error(ESTALE);
+            return;
+        }
+        let Some(file) = self.files.get(&ino) else {
+            reply.error(ENOENT);
+            return;
+        };
+        if offset < 0 {
+            reply.error(EINVAL);
+            return;
+        }
+
+        if !check_access(&file.attr, req, R_OK) || !file_handle.read {
+            reply.error(EACCES);
+            return;
+        }
+
+        let file_size = file.attr.size;
+        let _read_size = min(size, file_size as u32);
+        // file_handle.underlying_file_handle.offset = offset;
+        let Ok(_data) = self
+            .underlying_fs
+            .read_from_file(&mut file_handle.underlying_file_handle)
+        else {
+            reply.error(EIO);
+            return;
+        };
+
+        todo!()
+    }
+
+    fn write(
+        &mut self,
+        req: &Request<'_>,
+        ino: u64,
+        fh: u64,
+        offset: i64,
+        data: &[u8],
+        _write_flags: u32,
+        _flags: i32,
+        _lock_owner: Option<u64>,
+        reply: ReplyWrite,
+    ) {
+        let Some(file_handle) = self.file_handles.get_mut(&fh) else {
+            reply.error(EBADF);
+            return;
+        };
+        if file_handle.inode != ino {
+            reply.error(ESTALE);
+            return;
+        }
+        let Some(file) = self.files.get_mut(&ino) else {
+            reply.error(ENOENT);
+            return;
+        };
+        if offset < 0 || offset as u64 != file.attr.size {
+            reply.error(EINVAL);
+            return;
+        }
+
+        if !check_access(&file.attr, req, R_OK) || !file_handle.write {
+            reply.error(EACCES);
+            return;
+        }
+
+        if !self
+            .underlying_fs
+            .write_to_file(&mut file_handle.underlying_file_handle, data)
+            .is_ok()
+        {
+            reply.error(EIO);
+            return;
+        }
+
+        let now = SystemTime::now();
+        file.attr.ctime = now;
+        file.attr.mtime = now;
+        file.attr.size += data.len() as u64;
+        file.generation += 1;
+
+        reply.written(data.len() as u32);
+    }
+
+    fn release(
+        &mut self,
+        _req: &Request<'_>,
+        ino: u64,
+        _fh: u64,
+        _flags: i32,
+        _lock_owner: Option<u64>,
+        _flush: bool,
+        reply: ReplyEmpty,
+    ) {
+        let Some(file) = self.files.get_mut(&ino) else {
+            reply.error(EINVAL);
+            return;
+        };
+        if file.handles <= 0 {
+            reply.error(EINVAL);
+            return;
+        }
+        let Some(file_handle) = self.file_handles.remove(&ino) else {
+            reply.error(EINVAL);
+            return;
+        };
+        file_handle.underlying_file_handle.close();
+        file.handles -= 1;
+        reply.ok()
+    }
+
+    fn readdir(
+        &mut self,
+        req: &Request<'_>,
+        ino: u64,
+        _fh: u64,
+        offset: i64,
+        mut reply: ReplyDirectory,
+    ) {
+        if ino != 1 {
+            reply.error(EINVAL);
+            return;
+        }
+        let dir = self.files.get(&ino).unwrap();
+        if !check_access(&dir.attr, req, R_OK) {
+            reply.error(EACCES);
+            return;
+        }
+
+        let entries = self
+            .files
+            .iter()
+            .map(|(inode, file)| (inode, file.attr.kind, &file.name));
+        for (i, entry) in entries.enumerate().skip(offset as usize) {
+            let (inode, kind, name) = entry;
+            if reply.add(inode.clone(), offset + i as i64 + 1, kind, name) {
+                break;
+            }
+        }
+
+        reply.ok()
+    }
+
+    fn create(
+        &mut self,
+        req: &Request<'_>,
+        parent: u64,
+        name: &OsStr,
+        mode: u32,
+        umask: u32,
+        flags: i32,
+        reply: ReplyCreate,
+    ) {
+        let name = name.to_str().unwrap().to_owned();
+        if parent != 1 {
+            reply.error(EINVAL);
+            return;
+        }
+        let fh = self.get_new_fh();
+        let Ok(underlying_file_handle) = self
+            .underlying_fs
+            .create_file(name.clone(), (&self.chunker).clone())
+        else {
+            reply.error(EEXIST);
+            return;
+        };
+
+        let ino = self.get_new_inode();
+        let now = SystemTime::now();
+        let attr = FileAttr {
+            ino,
+            size: 0,
+            blocks: 0,
+            atime: now,
+            mtime: now,
+            ctime: now,
+            crtime: now,
+            kind: RegularFile,
+            perm: (mode & !umask) as u16,
+            nlink: 1,
+            uid: req.uid(),
+            gid: req.gid(),
+            rdev: 000,
+            blksize: 000,
+            flags: flags as u32,
+        };
+
+        let (read, write) = match flags & O_ACCMODE {
+            O_RDONLY => (true, false),
+            O_WRONLY => (false, true),
+            O_RDWR => (true, true),
+            // Exactly one access mode flag must be specified
+            _ => {
+                reply.error(EINVAL);
+                return;
+            }
+        };
+
+        let file_handle = FuseFileHandle {
+            underlying_file_handle,
+            inode: ino,
+            read,
+            write,
+        };
+        let file = FuseFile {
+            attr,
+            name: name.clone(),
+            generation: 0,
+            handles: 1,
+        };
+
+        reply.created(
+            &Duration::new(0, 0),
+            &file.attr,
+            0,
+            fh.clone(),
+            flags as u32,
+        );
+
+        self.files.insert(ino, file);
+        self.inodes.insert(name, ino);
+        self.file_handles.insert(fh, file_handle);
+    }
+}

--- a/src/system/fuse_filesystem.rs
+++ b/src/system/fuse_filesystem.rs
@@ -504,16 +504,20 @@ where
             reply.error(libc::EINVAL);
             return;
         }
-        let Some(file_handle) = self.file_handles.remove(&fh) else {
+        if !self.file_handles.contains_key(&fh) {
             reply.error(libc::EINVAL);
             return;
-        };
+        }
 
         if self.drop_and_shrink_cache(ino, fh).is_err() {
             reply.error(libc::EIO);
             return;
         }
 
+        let Some(file_handle) = self.file_handles.remove(&fh) else {
+            reply.error(libc::EINVAL);
+            return;
+        };
         file_handle.underlying_file_handle.close();
         let file = self.files.get_mut(&ino).unwrap();
         file.handles -= 1;

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -186,10 +186,8 @@ where
         let read_size_possible = last_span.offset() + last_span.len() - original_offset;
         let read_size_actual = min(size, read_size_possible);
         let data_extra_end = read_size_possible - read_size_actual; // amount of data from end to be removed
-        data_vectors
-            .last_mut()
-            .unwrap()
-            .truncate(last_span.len() - data_extra_end);
+        let last_vector = data_vectors.last_mut().unwrap();
+        last_vector.truncate(last_vector.len() - data_extra_end);
 
         Ok(data_vectors.concat())
     }

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -150,7 +150,7 @@ where
     /// Reads all contents of the file from beginning to end and returns them.
     pub fn read_file_complete(&self, handle: &FileHandle) -> io::Result<Vec<u8>> {
         let hashes = self.file_layer.read_complete(handle);
-        Ok(self.storage.retrieve(hashes)?.concat()) // it assumes that all retrieved data segments are in correct order
+        Ok(self.storage.retrieve(&hashes)?.concat()) // it assumes that all retrieved data segments are in correct order
     }
 
     /// Reads 1 MB of data from a file and returns it.
@@ -172,9 +172,8 @@ where
         if spans.is_empty() {
             return Ok(vec![]);
         }
-        let mut data_vectors = self
-            .storage
-            .retrieve(spans.iter().map(|span| span.hash()).collect())?;
+        let hashes: Vec<_> = spans.iter().map(|span| span.hash()).collect();
+        let mut data_vectors = self.storage.retrieve(&hashes)?;
 
         // Since we read by offset, which may be somewhere in the middle of the FileSpan offset,
         // we need to remove the extra at the beginning of the first span

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -157,7 +157,7 @@ where
     /// If file handle offset + 1 MB is greater than file size, then returns data starting from the offset to the end of the file
     ///
     /// **Careful:** it modifies internal `FileHandle` data. After using this `write_to_file` should not be used on the same FileHandle.
-    pub fn read_1mb_from_file(&self, handle: &mut FileHandle) -> io::Result<Vec<u8>> {
+    pub fn read_from_file(&self, handle: &mut FileHandle) -> io::Result<Vec<u8>> {
         self.read(handle, SEG_SIZE)
     }
 
@@ -178,11 +178,11 @@ where
         // Since we read by offset, which may be somewhere in the middle of the FileSpan offset,
         // we need to remove the extra at the beginning of the first span
         let first_span = spans.first().unwrap();
-        let last_span = spans.last().unwrap();
         let data_extra_start = original_offset - first_span.offset(); // amount of data from start to be removed
         data_vectors.first_mut().unwrap().drain(0..data_extra_start);
 
         // Same, we need to remove the extra at the end of the last span.
+        let last_span = spans.last().unwrap();
         let read_size_possible = last_span.offset() + last_span.len() - original_offset;
         let read_size_actual = min(size, read_size_possible);
         let data_extra_end = read_size_possible - read_size_actual; // amount of data from end to be removed
@@ -222,7 +222,7 @@ where
             .open(path)?;
 
         loop {
-            let data = self.read_1mb_from_file(&mut handle)?;
+            let data = self.read_from_file(&mut handle)?;
 
             if data.is_empty() {
                 break;

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -176,11 +176,14 @@ where
             .storage
             .retrieve(spans.iter().map(|span| span.hash()).collect())?;
 
+        // Since we read by offset, which may be somewhere in the middle of the FileSpan offset,
+        // we need to remove the extra at the beginning of the first span
         let first_span = spans.first().unwrap();
         let last_span = spans.last().unwrap();
         let data_extra_start = original_offset - first_span.offset(); // amount of data from start to be removed
         data_vectors.first_mut().unwrap().drain(0..data_extra_start);
 
+        // Same, we need to remove the extra at the end of the last span.
         let read_size_possible = last_span.offset() + last_span.len() - original_offset;
         let read_size_actual = min(size, read_size_possible);
         let data_extra_end = read_size_possible - read_size_actual; // amount of data from end to be removed

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -167,7 +167,7 @@ where
     /// If `size` + file handle offset is greater than file size, then returns data starting from the offset to the end of the file
     /// **Careful:** it modifies internal `FileHandle` data. After using this `write_to_file` should not be used on the same FileHandle.
     pub fn read(&self, handle: &mut FileHandle, size: usize) -> io::Result<Vec<u8>> {
-        let original_offset = handle.offset().clone();
+        let original_offset = handle.offset();
         let spans = self.file_layer.read(handle, size);
         if spans.is_empty() {
             return Ok(vec![]);

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -12,6 +12,7 @@ use super::{ChunkHash, ChunkerRef, Hasher, WriteMeasurements};
 
 pub mod database;
 pub mod file_layer;
+pub mod fuse_filesystem;
 pub mod scrub;
 pub mod storage;
 

--- a/src/system/scrub.rs
+++ b/src/system/scrub.rs
@@ -26,8 +26,8 @@ use super::storage::DataContainer;
 ///    [DataContainer::extract] or [DataContainer::extract_mut] should be used.
 ///
 /// 2. A target map, which contains `Key`-`Vec<u8>` pairs, where `Key` is a generic value determined by the implementation.
-///     The way data is stored is determined by the target map implementation, the only information known to the scrubber is that
-///     the target map implements [Database] trait. It should only be used for storage purposes and not contain any algorithm logic.
+///    The way data is stored is determined by the target map implementation, the only information known to the scrubber is that
+///    the target map implements [Database] trait. It should only be used for storage purposes and not contain any algorithm logic.
 pub trait Scrub<Hash: ChunkHash, B, Key, T>: Send
 where
     Hash: ChunkHash,

--- a/src/system/scrub.rs
+++ b/src/system/scrub.rs
@@ -18,7 +18,7 @@ use super::storage::DataContainer;
 ///
 /// After moving the data from `database` to `target_map`, we should be able to have access to it via the `database`.
 /// Therefore, after moving, we should leave a `Vec<Key>` in place of the source chunk. It is done via [DataContainer::make_target] method.
-/// Not using it will lead to either not getting any benefits from the algorithm, or to being unable to access the initial chunk anymore, if it was deleted.
+/// Not using it will lead to either not getting any benefits from the algorithm or to being unable to access the initial chunk anymore if it is deleted.
 ///
 /// # Arguments
 /// The only method [scrub][Scrub::scrub] takes two arguments:
@@ -40,7 +40,7 @@ where
     /// [DataContainer::extract] or [DataContainer::extract_mut] should be used.
     ///
     /// If the chunk is suitable for being transferred to the `target_map`, it should NOT be deleted, but instead be replaced by the `target_map`'s keys,
-    /// using which the original chunk can be restored. This is accomplished by the [DataContainer::make_target] method.
+    /// using which the original chunk can be restored. This is achieved by the [DataContainer::make_target] method.
     ///
     /// It should also gather information to return the [measurements][ScrubMeasurements].
     ///
@@ -55,7 +55,7 @@ where
     ///
     /// # CDC Database
     /// We should be able to iterate over the `database` to process all chunks we had stored before.
-    /// The [IntoIterator] trait should be implemented for `database`, but it should not be a big concern, because the only structure that should be implemented
+    /// The [IntoIterator] trait should be implemented for `database`, but it should not be a big concern because the only structure that should be implemented
     /// for the algorithm is the scrubber itself. `database` should be considered a given entity, along with the `target_map`.
     fn scrub<'a>(&mut self, database: &mut B, target_map: &mut T) -> io::Result<ScrubMeasurements>
     where

--- a/src/system/scrub.rs
+++ b/src/system/scrub.rs
@@ -26,9 +26,9 @@ use super::storage::DataContainer;
 ///    [DataContainer::extract] or [DataContainer::extract_mut] should be used.
 ///
 /// 2. A target map, which contains `Key`-`Vec<u8>` pairs, where `Key` is a generic value determined by the implementation.
-///    The way data is stored is determined by the target map implementation, the only information known to the scrubber is that
-///    the target map implements [Database] trait. It should only be used for storage purposes and not contain any algorithm logic.
-pub trait Scrub<Hash: ChunkHash, B, Key, T>
+///     The way data is stored is determined by the target map implementation, the only information known to the scrubber is that
+///     the target map implements [Database] trait. It should only be used for storage purposes and not contain any algorithm logic.
+pub trait Scrub<Hash: ChunkHash, B, Key, T>: Send
 where
     Hash: ChunkHash,
     B: IterableDatabase<Hash, DataContainer<Key>>,

--- a/src/system/storage.rs
+++ b/src/system/storage.rs
@@ -138,7 +138,7 @@ where
 
     /// Retrieves the data from the storage based on hashes of the data [`segments`][Segment],
     /// or Error(NotFound) if some of the hashes were not present in the base.
-    pub fn retrieve(&self, request: Vec<&Hash>) -> io::Result<Vec<Vec<u8>>> {
+    pub fn retrieve(&self, request: &[&Hash]) -> io::Result<Vec<Vec<u8>>> {
         let retrieved = self.database.get_multi(request)?;
 
         retrieved
@@ -147,7 +147,7 @@ where
                 Data::Chunk(chunk) => Ok(chunk.clone()),
                 Data::TargetChunk(keys) => Ok(self
                     .target_map
-                    .get_multi(keys.iter().collect())?
+                    .get_multi(&keys.into_iter().collect::<Vec<_>>())?
                     .into_iter()
                     .flatten()
                     .collect()),

--- a/src/system/storage.rs
+++ b/src/system/storage.rs
@@ -73,8 +73,8 @@ where
 
     /// Writes 1 MB of data to the [`base`][crate::base::Base] storage after deduplication.
     ///
-    /// Returns resulting lengths of [chunks][crate::chunker::Chunk] with corresponding hash,
-    /// along with amount of time spent on chunking and hashing.
+    /// Returns the resulting lengths of [chunks][crate::chunker::Chunk] with the corresponding hash,
+    /// along with the amount of time spent on chunking and hashing.
     pub fn write(&mut self, data: &[u8], chunker: &ChunkerRef) -> io::Result<Vec<SpansInfo<Hash>>> {
         let mut writer = StorageWriter::new(chunker, &mut self.hasher);
 
@@ -137,7 +137,7 @@ where
     }
 
     /// Retrieves the data from the storage based on hashes of the data [`segments`][Segment],
-    /// or Error(NotFound) if some of the hashes were not present in the base.
+    /// or Error(NotFound) if some hashes were not present in the base.
     pub fn retrieve(&self, request: &[&Hash]) -> io::Result<Vec<Vec<u8>>> {
         let retrieved = self.database.get_multi(request)?;
 
@@ -199,7 +199,7 @@ where
             })
     }
 
-    /// Calculates deduplication ratio of the storage, not accounting for chunks processed with scrubber.
+    /// Calculates a deduplication ratio of the storage, not accounting for chunks processed with scrubber.
     pub fn cdc_dedup_ratio(&self) -> f64 {
         (self.size_written as f64) / (self.total_cdc_size() as f64)
     }
@@ -297,8 +297,8 @@ where
 
     /// Writes 1 MB of data to the [`base`][crate::base::Base] storage after deduplication.
     ///
-    /// Returns resulting lengths of [chunks][crate::chunker::Chunk] with corresponding hash,
-    /// along with amount of time spent on chunking and hashing.
+    /// Returns the resulting lengths of [chunks][crate::chunker::Chunk] with the corresponding hash,
+    /// along with the amount of time spent on chunking and hashing.
     fn write<K, B: Database<Hash, DataContainer<K>>>(
         &mut self,
         data: &[u8],

--- a/src/system/storage.rs
+++ b/src/system/storage.rs
@@ -138,7 +138,7 @@ where
 
     /// Retrieves the data from the storage based on hashes of the data [`segments`][Segment],
     /// or Error(NotFound) if some of the hashes were not present in the base.
-    pub fn retrieve(&self, request: &[Hash]) -> io::Result<Vec<Vec<u8>>> {
+    pub fn retrieve(&self, request: Vec<&Hash>) -> io::Result<Vec<Vec<u8>>> {
         let retrieved = self.database.get_multi(request)?;
 
         retrieved
@@ -147,7 +147,7 @@ where
                 Data::Chunk(chunk) => Ok(chunk.clone()),
                 Data::TargetChunk(keys) => Ok(self
                     .target_map
-                    .get_multi(keys)?
+                    .get_multi(keys.iter().collect())?
                     .into_iter()
                     .flatten()
                     .collect()),

--- a/src/system/storage.rs
+++ b/src/system/storage.rs
@@ -147,7 +147,7 @@ where
                 Data::Chunk(chunk) => Ok(chunk.clone()),
                 Data::TargetChunk(keys) => Ok(self
                     .target_map
-                    .get_multi(&keys.into_iter().collect::<Vec<_>>())?
+                    .get_multi(&keys.iter().collect::<Vec<_>>())?
                     .into_iter()
                     .flatten()
                     .collect()),

--- a/tests/filesystem.rs
+++ b/tests/filesystem.rs
@@ -91,7 +91,7 @@ fn write_read_blocks_test() {
         buffer.extend_from_slice(&buf);
     }
     assert_eq!(buffer.len(), MB * 3 + 50);
-    assert!(complete == buffer);
+    assert_eq!(complete, buffer);
     assert_eq!(fs.read_from_file(&mut handle).unwrap(), []);
 }
 
@@ -147,11 +147,11 @@ fn non_iterable_database_can_be_used_with_fs() {
     struct DummyDatabase;
 
     impl Database<Vec<u8>, DataContainer<()>> for DummyDatabase {
-        fn insert(&mut self, _key: Vec<u8>, _value: DataContainer<()>) -> std::io::Result<()> {
+        fn insert(&mut self, _key: Vec<u8>, _value: DataContainer<()>) -> io::Result<()> {
             unimplemented!()
         }
 
-        fn get(&self, _key: &Vec<u8>) -> std::io::Result<DataContainer<()>> {
+        fn get(&self, _key: &Vec<u8>) -> io::Result<DataContainer<()>> {
             unimplemented!()
         }
 

--- a/tests/filesystem.rs
+++ b/tests/filesystem.rs
@@ -87,12 +87,12 @@ fn write_read_blocks_test() {
     let mut handle = fs.open_file("file", LeapChunker::default()).unwrap();
     let mut buffer = Vec::with_capacity(MB * 3 + 50);
     for _ in 0..4 {
-        let buf = fs.read_1mb_from_file(&mut handle).unwrap();
+        let buf = fs.read_from_file(&mut handle).unwrap();
         buffer.extend_from_slice(&buf);
     }
     assert_eq!(buffer.len(), MB * 3 + 50);
     assert!(complete == buffer);
-    assert_eq!(fs.read_1mb_from_file(&mut handle).unwrap(), []);
+    assert_eq!(fs.read_from_file(&mut handle).unwrap(), []);
 }
 
 #[test]
@@ -107,7 +107,7 @@ fn read_file_with_size_less_than_1mb() {
     println!("{:?}", measurements);
 
     let mut handle = fs.open_file_readonly("file").unwrap();
-    assert_eq!(fs.read_1mb_from_file(&mut handle).unwrap(), ones);
+    assert_eq!(fs.read_from_file(&mut handle).unwrap(), ones);
 }
 
 #[test]
@@ -237,7 +237,7 @@ fn readonly_file_handle_cannot_write_can_read() {
     assert_eq!(read.len(), MB);
     assert_eq!(read, [1; MB]);
 
-    let _ = fs.read_1mb_from_file(&mut ro_fh).unwrap();
+    let _ = fs.read_from_file(&mut ro_fh).unwrap();
 
     // can close
     let measurements = fs.close_file(ro_fh).unwrap();

--- a/tests/filesystem.rs
+++ b/tests/filesystem.rs
@@ -38,7 +38,7 @@ fn write_read_with_strange_size() {
     let actual = fs.read(&mut handle, 2 * MB + 3).unwrap();
     assert_eq!(actual, ones_w_twos);
 
-    handle.set_offset(433 * KB + 2 * MB + 3 + MB / 2).unwrap();
+    handle.set_offset(433 * KB + 2 * MB + 3 + MB / 2);
     let actual = fs.read(&mut handle, 10 * MB).unwrap();
     assert_eq!(actual, vec![2; MB + MB / 2]);
 }

--- a/tests/fuse_filesystem.rs
+++ b/tests/fuse_filesystem.rs
@@ -3,6 +3,7 @@ use chunkfs::hashers::SimpleHasher;
 use chunkfs::{FuseFS, MB};
 use filetime::FileTime;
 use fuser::BackgroundSession;
+use fuser::MountOption::AutoUnmount;
 use std::collections::HashMap;
 use std::ffi::OsString;
 use std::fs;
@@ -29,7 +30,7 @@ impl FuseFixture {
         let fuse_fs = FuseFS::new(db, SimpleHasher, SuperChunker::default());
         fs::create_dir_all(&mount_point).unwrap();
 
-        let fuse_session = fuser::spawn_mount2(fuse_fs, &mount_point, &[]).unwrap();
+        let fuse_session = fuser::spawn_mount2(fuse_fs, &mount_point, &[AutoUnmount]).unwrap();
 
         Self {
             mount_point,

--- a/tests/fuse_filesystem.rs
+++ b/tests/fuse_filesystem.rs
@@ -442,7 +442,7 @@ fn read_cache() {
     );
 
     actual = vec![10; MB];
-    assert_eq!(file.read_at(&mut actual, 11 * MB as u64).unwrap(), 1 * MB);
+    assert_eq!(file.read_at(&mut actual, 11 * MB as u64).unwrap(), MB);
     assert_eq!(
         actual, [1; MB],
         "read cache from start + epsilon to end - epsilon is correct"
@@ -627,7 +627,7 @@ fn read_first_chunk_piece() {
     assert_eq!(60, file.read_at(&mut actual, 970).unwrap());
     assert_eq!(
         actual,
-        vec![[0; 30], [1; 30]].concat(),
+        [[0; 30], [1; 30]].concat(),
         "read from start + epsilon to end + epsilon of first chunk is correct"
     );
 

--- a/tests/fuse_filesystem.rs
+++ b/tests/fuse_filesystem.rs
@@ -1,0 +1,42 @@
+use chunkfs::chunkers::SuperChunker;
+use chunkfs::hashers::SimpleHasher;
+use chunkfs::FuseFS;
+use std::collections::HashMap;
+use std::fs;
+use std::fs::OpenOptions;
+use std::io::{Read, Write};
+use std::os::unix::fs::FileExt;
+
+const MOUNT_POINT: &str = "./mount_point";
+
+#[test]
+fn write_fuse_fs() {
+    let db = HashMap::default();
+    let fuse_fs = FuseFS::new(db, SimpleHasher, SuperChunker::default());
+
+    fs::create_dir_all(MOUNT_POINT).unwrap();
+
+    let session = fuser::spawn_mount2(fuse_fs, MOUNT_POINT, &vec![]).unwrap();
+
+    let file_path = format!("{}/{}", MOUNT_POINT, "file");
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create(true)
+        .open(&file_path)
+        .unwrap();
+
+    let mut data1 = vec![1u8; 2000];
+    let mut data2 = vec![2u8; 5000];
+    file.write(&data1).unwrap();
+    file.write_at(&data2, data1.len() as u64).unwrap();
+
+    let mut file = OpenOptions::new().read(true).open(&file_path).unwrap();
+    data1.append(&mut data2);
+    let mut actual = Vec::new();
+    file.read_to_end(&mut actual).unwrap();
+    assert_eq!(actual, data1);
+
+    drop(session);
+
+    fs::remove_dir_all(MOUNT_POINT).unwrap();
+}

--- a/tests/fuse_filesystem.rs
+++ b/tests/fuse_filesystem.rs
@@ -10,7 +10,7 @@ use std::fs;
 use std::fs::{File, OpenOptions, Permissions};
 use std::io::{Read, Write};
 use std::os::unix::fs::{FileExt, MetadataExt, PermissionsExt};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 use uuid::Uuid;
 
@@ -19,13 +19,14 @@ fn generate_unique_mount_point() -> String {
 }
 
 struct FuseFixture {
-    mount_point: String,
+    mount_point: PathBuf,
     fuse_session: Option<BackgroundSession>,
 }
 
 impl FuseFixture {
     fn default() -> Self {
-        let mount_point = generate_unique_mount_point();
+        let mount_dir = Path::new("mount_dir");
+        let mount_point = mount_dir.join(generate_unique_mount_point());
         let db = HashMap::default();
         let fuse_fs = FuseFS::new(db, SimpleHasher, SuperChunker::default());
         fs::create_dir_all(&mount_point).unwrap();

--- a/tests/fuse_filesystem.rs
+++ b/tests/fuse_filesystem.rs
@@ -76,6 +76,7 @@ fn get_metadata_times(file: &File) -> (u64, u64, u64) {
         metadata.ctime() as u64,
     )
 }
+
 #[test]
 fn metadata_times() {
     let fuse_fixture = FuseFixture::default();
@@ -147,6 +148,7 @@ fn manual_setattr() {
     assert_eq!(mtime2, to_unix_secs(&now_minus100s));
     assert!(ctime2 > ctime1);
 }
+
 #[test]
 fn readdir() {
     let fuse_fixture = FuseFixture::default();
@@ -497,7 +499,7 @@ fn concurrent_file_handles() {
 }
 
 #[test]
-fn offset_change_not_affects_cache_drop() {
+fn offset_change_does_not_affect_cache_drop() {
     let fuse_fixture = FuseFixture::default();
     let mount_point = Path::new(&fuse_fixture.mount_point);
 

--- a/tests/fuse_filesystem.rs
+++ b/tests/fuse_filesystem.rs
@@ -302,6 +302,7 @@ fn read_dropped_cache() {
     let file_path = mount_point.join("file");
     let mut file = OpenOptions::new()
         .create(true)
+        .truncate(true)
         .write(true)
         .open(&file_path)
         .unwrap();
@@ -345,6 +346,7 @@ fn read_cache() {
     let file_path = mount_point.join("file");
     let mut file = OpenOptions::new()
         .create(true)
+        .truncate(true)
         .write(true)
         .open(&file_path)
         .unwrap();

--- a/tests/fuse_filesystem.rs
+++ b/tests/fuse_filesystem.rs
@@ -165,7 +165,7 @@ fn readdir() {
         files.push(path.file_name().unwrap().to_owned());
     }
     assert!(files.contains(&OsString::from("file1")));
-    assert!(files.contains(&OsString::from("file1")));
+    assert!(files.contains(&OsString::from("file2")));
     assert_eq!(files.len(), 2)
 }
 

--- a/tests/fuse_filesystem.rs
+++ b/tests/fuse_filesystem.rs
@@ -306,38 +306,52 @@ fn read_dropped_cache() {
         .create(true)
         .truncate(true)
         .write(true)
-        .open(&file_path)
-        .unwrap();
-    file.write_all(&[0; 10 * MB]).unwrap();
-    drop(file);
-    let file = OpenOptions::new()
-        .write(true)
         .read(true)
         .open(&file_path)
         .unwrap();
-    file.write_all_at(&[1; 10 * MB], file_size(&file)).unwrap();
+    file.write_all(&[0; 10 * MB]).unwrap();
+    file.flush().unwrap();
+    file.write_all(&[1; 3 * MB]).unwrap();
 
-    // read dropped cache from start to end - epsilon
-    let mut actual = vec![10; 7 * MB];
+    let mut actual = vec![10; 14 * MB];
+    assert_eq!(file.read_at(&mut actual, 0).unwrap(), 13 * MB);
+    let expected = [vec![0; 10 * MB], vec![1; 3 * MB], vec![10; MB]].concat();
+    assert_eq!(
+        actual, expected,
+        "read entire file with dropped and dirty cache is correct"
+    );
+
+    actual = vec![10; 7 * MB];
     assert_eq!(file.read_at(&mut actual, 0).unwrap(), 7 * MB);
-    assert_eq!(actual, [0; 7 * MB]);
+    assert_eq!(
+        actual,
+        [0; 7 * MB],
+        "read dropped cache from start to end - epsilon is correct"
+    );
 
-    // read dropped cache from start to end + epsilon
-    let mut actual = vec![10; 12 * MB];
+    actual = vec![10; 12 * MB];
     assert_eq!(file.read_at(&mut actual, 0).unwrap(), 12 * MB);
     let expected = [vec![0; 10 * MB], vec![1; 2 * MB]].concat();
-    assert_eq!(actual, expected);
+    assert_eq!(
+        actual, expected,
+        "read dropped cache from start to end + epsilon is correct"
+    );
 
-    // read dropped cache from start + epsilon to end - epsilon
     actual = vec![10; 7 * MB];
-    assert_eq!(file.read_at(&mut actual, 2 * MB as u64).unwrap(), 7 * MB);
-    assert_eq!(actual, [0; 7 * MB]);
+    assert_eq!(file.read_at(&mut actual, MB as u64).unwrap(), 7 * MB);
+    assert_eq!(
+        actual,
+        [0; 7 * MB],
+        "read dropped cache from start + epsilon to end - epsilon is correct"
+    );
 
-    // read dropped cache from start + epsilon to end + epsilon
-    actual = vec![10; 7 * MB];
-    assert_eq!(file.read_at(&mut actual, 7 * MB as u64).unwrap(), 7 * MB);
-    let expected = [vec![0; 3 * MB], vec![1; 4 * MB]].concat();
-    assert_eq!(actual, expected);
+    actual = vec![10; 10 * MB];
+    assert_eq!(file.read_at(&mut actual, 7 * MB as u64).unwrap(), 6 * MB);
+    let expected = [vec![0; 3 * MB], vec![1; 3 * MB], vec![10; 4 * MB]].concat();
+    assert_eq!(
+        actual, expected,
+        "read dropped cache from start + epsilon to end + epsilon is correct"
+    );
 }
 
 #[test]
@@ -350,33 +364,51 @@ fn read_cache() {
         .create(true)
         .truncate(true)
         .write(true)
-        .open(&file_path)
-        .unwrap();
-    file.write_all(&[0; 10 * MB]).unwrap();
-    drop(file);
-    let file = OpenOptions::new()
-        .write(true)
         .read(true)
         .open(&file_path)
         .unwrap();
-    file.write_all_at(&[1; 20 * MB], file_size(&file)).unwrap();
+    file.write_all(&[0; 10 * MB]).unwrap();
+    file.flush().unwrap();
+    file.write_all(&[1; 3 * MB]).unwrap();
 
-    // read cache from start - epsilon to end + epsilon
-    let mut actual = vec![10; 30 * MB];
-    assert_eq!(file.read_at(&mut actual, 5 * MB as u64).unwrap(), 25 * MB);
-    let expected = [vec![0; 5 * MB], vec![1; 20 * MB], vec![10; 5 * MB]].concat();
-    assert_eq!(actual, expected);
+    let mut actual = vec![10; 15 * MB];
+    assert_eq!(file.read_at(&mut actual, 0).unwrap(), 13 * MB);
+    let expected = [vec![0; 10 * MB], vec![1; 3 * MB], vec![10; 2 * MB]].concat();
+    assert_eq!(
+        actual, expected,
+        "read entire file with dropped and dirty cache is correct"
+    );
 
-    // read cache from start to end - epsilon
-    actual = vec![10; 15 * MB];
-    assert_eq!(file.read_at(&mut actual, 10 * MB as u64).unwrap(), 15 * MB);
-    assert_eq!(actual, [1; 15 * MB]);
+    actual = vec![10; 10 * MB];
+    assert_eq!(file.read_at(&mut actual, 5 * MB as u64).unwrap(), 8 * MB);
+    let expected = [vec![0; 5 * MB], vec![1; 3 * MB], vec![10; 2 * MB]].concat();
+    assert_eq!(
+        actual, expected,
+        "read cache from start - epsilon to end + epsilon is correct"
+    );
 
-    // read cache from start + epsilon to end + epsilon
-    actual = vec![10; 40 * MB];
-    assert_eq!(file.read_at(&mut actual, 12 * MB as u64).unwrap(), 18 * MB);
-    let expected = [vec![1; 18 * MB], vec![10; 22 * MB]].concat();
-    assert_eq!(actual, expected);
+    actual = vec![10; 2 * MB];
+    assert_eq!(file.read_at(&mut actual, 10 * MB as u64).unwrap(), 2 * MB);
+    assert_eq!(
+        actual,
+        [1; 2 * MB],
+        "read cache from start to end - epsilon is correct"
+    );
+
+    actual = vec![10; 5 * MB];
+    assert_eq!(file.read_at(&mut actual, 11 * MB as u64).unwrap(), 2 * MB);
+    let expected = [vec![1; 2 * MB], vec![10; 3 * MB]].concat();
+    assert_eq!(
+        actual, expected,
+        "read cache from start + epsilon to end + epsilon is correct"
+    );
+
+    actual = vec![10; MB];
+    assert_eq!(file.read_at(&mut actual, 11 * MB as u64).unwrap(), 1 * MB);
+    assert_eq!(
+        actual, [1; MB],
+        "read cache from start + epsilon to end - epsilon is correct"
+    );
 }
 
 #[test]

--- a/tests/fuse_filesystem.rs
+++ b/tests/fuse_filesystem.rs
@@ -195,7 +195,7 @@ fn permissions() {
 }
 
 #[test]
-fn write_not_to_end_fails() {
+fn create_dir_fails() {
     let fuse_fixture = FuseFixture::default();
     let mount_point = Path::new(&fuse_fixture.mount_point);
 
@@ -205,7 +205,7 @@ fn write_not_to_end_fails() {
 }
 
 #[test]
-fn create_dir_fails() {
+fn write_not_to_end_fails() {
     let fuse_fixture = FuseFixture::default();
     let mount_point = Path::new(&fuse_fixture.mount_point);
 

--- a/tests/fuse_filesystem.rs
+++ b/tests/fuse_filesystem.rs
@@ -185,7 +185,7 @@ fn permissions() {
     };
     let read_denied = || {
         let res = OpenOptions::new().read(true).open(&file_path);
-        assert!(res.is_err());
+        assert_eq!(res.unwrap_err().kind(), std::io::ErrorKind::PermissionDenied);
     };
     let write_ok = || {
         let file = OpenOptions::new().write(true).open(&file_path).unwrap();
@@ -194,7 +194,7 @@ fn permissions() {
     };
     let write_denied = || {
         let res = OpenOptions::new().write(true).open(&file_path);
-        assert!(res.is_err());
+        assert_eq!(res.unwrap_err().kind(), std::io::ErrorKind::PermissionDenied);
     };
 
     let perms: Vec<_> = (0o000..=0o777).map(Permissions::from_mode).collect();
@@ -221,7 +221,7 @@ fn create_dir_fails() {
 
     let dir_path = mount_point.join("directory");
     let res = fs::create_dir(&dir_path);
-    assert!(res.is_err());
+    assert_eq!(res.unwrap_err().raw_os_error(), Some(libc::ENOSYS));
 }
 
 #[test]

--- a/tests/fuse_filesystem.rs
+++ b/tests/fuse_filesystem.rs
@@ -1,24 +1,28 @@
 use chunkfs::chunkers::SuperChunker;
 use chunkfs::hashers::SimpleHasher;
-use chunkfs::FuseFS;
+use chunkfs::{FuseFS, MB};
 use std::collections::HashMap;
 use std::fs;
 use std::fs::OpenOptions;
 use std::io::{Read, Write};
 use std::os::unix::fs::FileExt;
+use uuid::Uuid;
 
-const MOUNT_POINT: &str = "./mount_point";
+fn generate_unique_mount_point() -> String {
+    Uuid::new_v4().to_string()
+}
 
 #[test]
 fn write_fuse_fs() {
     let db = HashMap::default();
     let fuse_fs = FuseFS::new(db, SimpleHasher, SuperChunker::default());
+    let mount_point = generate_unique_mount_point();
 
-    fs::create_dir_all(MOUNT_POINT).unwrap();
+    fs::create_dir_all(&mount_point).unwrap();
 
-    let session = fuser::spawn_mount2(fuse_fs, MOUNT_POINT, &vec![]).unwrap();
+    let session = fuser::spawn_mount2(fuse_fs, &mount_point, &vec![]).unwrap();
 
-    let file_path = format!("{}/{}", MOUNT_POINT, "file");
+    let file_path = format!("{}/{}", &mount_point, "file");
     let mut file = OpenOptions::new()
         .write(true)
         .create(true)
@@ -27,7 +31,7 @@ fn write_fuse_fs() {
 
     let mut data1 = vec![1u8; 2000];
     let mut data2 = vec![2u8; 5000];
-    file.write(&data1).unwrap();
+    file.write_all(&data1).unwrap();
     file.write_at(&data2, data1.len() as u64).unwrap();
 
     let mut file = OpenOptions::new().read(true).open(&file_path).unwrap();
@@ -37,6 +41,50 @@ fn write_fuse_fs() {
     assert_eq!(actual, data1);
 
     drop(session);
+    fs::remove_dir_all(&mount_point).unwrap();
+}
 
-    fs::remove_dir_all(MOUNT_POINT).unwrap();
+#[test]
+fn different_data_writes() {
+    let db = HashMap::default();
+    let fuse_fs = FuseFS::new(db, SimpleHasher, SuperChunker::default());
+    let mount_point = generate_unique_mount_point();
+
+    fs::create_dir_all(&mount_point).unwrap();
+
+    let session = fuser::spawn_mount2(fuse_fs, &mount_point, &vec![]).unwrap();
+
+    let file_path = format!("{}/{}", &mount_point, "file");
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create(true)
+        .open(&file_path)
+        .unwrap();
+
+    let mut data1 = vec![1u8; 500];
+    let mut data2 = vec![2u8; 700];
+    let data3 = vec![3u8; 3 * MB];
+    let mut data4 = vec![4u8; 10 * MB];
+    file.write_all(&data1).unwrap();
+    file.write_all(&data2).unwrap();
+    file.write_all(&data3).unwrap();
+    file.write_all(&data4).unwrap();
+
+    let mut file = OpenOptions::new().read(true).open(&file_path).unwrap();
+    data1.append(&mut data2);
+    data1.append(&mut vec![3u8; MB + 11]);
+    let mut actual = vec![0u8; 500 + 700 + MB + 11];
+    file.read_exact(&mut actual).unwrap();
+    assert_eq!(actual, data1);
+    let first_read_len = actual.len();
+
+    let mut expected = vec![3u8; MB - 11];
+    expected.append(&mut data4);
+    let mut actual = vec![0u8; expected.len()];
+    file.read_exact_at(&mut actual, (first_read_len + MB) as u64)
+        .unwrap();
+    assert_eq!(actual, expected);
+
+    drop(session);
+    fs::remove_dir_all(&mount_point).unwrap();
 }


### PR DESCRIPTION
Also added the ability to read the exact size from a file and at a specific offset.
Remove Hash copying in FileLayer::read_complete and FileLayer::read methods.