### PR TITLE
refactor: extract clustering metrics from ScrubMeasurements into Scru…

### DIFF
--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 
 use database::{Database, IterableDatabase};
 use file_layer::{FileHandle, FileLayer};
-use scrub::{Scrub, ScrubMeasurements};
+use scrub::{Scrub, ScrubberReport};
 use storage::{ChunkStorage, DataContainer};
 
 use super::{ChunkHash, ChunkerRef, Hasher, WriteMeasurements};
@@ -242,7 +242,7 @@ where
     /// otherwise it returns [`ErrorKind::InvalidInput`][io::ErrorKind::InvalidInput].
     ///
     /// For more info check [`Scrub`][Scrub] trait and its [`scrub`][Scrub::scrub] method.
-    pub fn scrub(&mut self) -> io::Result<ScrubMeasurements> {
+    pub fn scrub(&mut self) -> io::Result<ScrubberReport> {
         self.storage.scrub()
     }
 

--- a/src/system/scrub.rs
+++ b/src/system/scrub.rs
@@ -58,7 +58,7 @@ where
     /// We should be able to iterate over the `database` to process all chunks we had stored before.
     /// The [IntoIterator] trait should be implemented for `database`, but it should not be a big concern, because the only structure that should be implemented
     /// for the algorithm is the scrubber itself. `database` should be considered a given entity, along with the `target_map`.
-    fn scrub<'a>(&mut self, database: &mut B, target_map: &mut T) -> io::Result<ScrubMeasurements>
+    fn scrub<'a>(&mut self, database: &mut B, target_map: &mut T) -> io::Result<ScrubberReport>
     where
         Hash: 'a,
         Key: 'a;
@@ -77,6 +77,11 @@ pub struct ScrubMeasurements {
     pub running_time: Duration,
     /// The amount of data left untouched (in bytes).
     pub data_left: usize,
+}
+
+#[derive(Debug, Default, PartialEq, Clone)]
+pub struct SbcScrubMeasurements {
+    pub base_measurements: ScrubMeasurements,
     /// All information about clusterization:
     /// 1. Total cluster size (number of vertices).
     /// 2. Number of clusters (total number of parent vertices).
@@ -84,7 +89,13 @@ pub struct ScrubMeasurements {
     /// 4. Distance to the parent vertex.
     /// 5. Distance between clusters (between parent vertices).
     /// 6. Deduplication coefficient for each cluster.
-    pub clusterization_report: ClusteringMeasurements,
+    pub clustering_measurements: ClusteringMeasurements,
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub enum ScrubberReport {
+    Generic(ScrubMeasurements),
+    Sbc(Box<SbcScrubMeasurements>),
 }
 
 #[derive(Debug, Default, PartialEq, Clone)]
@@ -106,24 +117,20 @@ pub struct ClusteringMeasurements {
     pub cluster_dedup_ratio: HashMap<u32, f64>,
 }
 
+pub struct DumbScrubber;
+
 pub struct CopyScrubber;
 
-pub struct DumbScrubber;
 impl<Hash, B, T> Scrub<Hash, B, Hash, T> for CopyScrubber
 where
     Hash: ChunkHash,
     B: IterableDatabase<Hash, DataContainer<Hash>>,
     T: Database<Hash, Vec<u8>>,
 {
-    fn scrub<'a>(&mut self, database: &mut B, target: &mut T) -> io::Result<ScrubMeasurements>
+    fn scrub<'a>(&mut self, database: &mut B, target: &mut T) -> io::Result<ScrubberReport>
     where
         Hash: 'a,
     {
-        let mut total_cluster_size: usize = 0;
-        let mut number_of_vertices_in_cluster = HashMap::new();
-        let mut distance_to_other_clusters = HashMap::new();
-        let mut parent_vertices: Vec<usize> = Vec::new();
-        let cluster_dedup_ratio = HashMap::new();
         let now = Instant::now();
         let mut processed_data = 0;
 
@@ -131,46 +138,19 @@ where
             match container.extract() {
                 Data::Chunk(chunk) => {
                     target.insert(hash.clone(), chunk.clone())?;
-                    total_cluster_size += 1;
                     processed_data += chunk.len();
-                    number_of_vertices_in_cluster.insert(total_cluster_size as u32, 1);
-                    parent_vertices.push(total_cluster_size);
                 }
                 Data::TargetChunk(_) => (),
             }
             container.make_target(vec![hash.clone()]);
         }
 
-        for i in 0..parent_vertices.len() {
-            let mut distances = Vec::new();
-
-            for j in 0..parent_vertices.len() {
-                if i != j {
-                    let distance = parent_vertices[i].abs_diff(parent_vertices[j]);
-                    distances.push(distance);
-                }
-            }
-
-            distance_to_other_clusters.insert(parent_vertices[i] as u32, distances);
-        }
-
         let running_time = now.elapsed();
-        let number_of_clusters = total_cluster_size;
-        let distance_to_vertices_in_cluster = HashMap::new();
-        let clusterization_report = ClusteringMeasurements {
-            total_cluster_size,
-            number_of_clusters,
-            number_of_vertices_in_cluster,
-            distance_to_vertices_in_cluster,
-            distance_to_other_clusters,
-            cluster_dedup_ratio,
-        };
-        Ok(ScrubMeasurements {
+        Ok(ScrubberReport::Generic(ScrubMeasurements {
             processed_data,
             running_time,
             data_left: 0,
-            clusterization_report,
-        })
+        }))
     }
 }
 
@@ -180,12 +160,12 @@ where
     B: IterableDatabase<Hash, DataContainer<Key>>,
     T: Database<Key, Vec<u8>>,
 {
-    fn scrub<'a>(&mut self, _database: &mut B, _target: &mut T) -> io::Result<ScrubMeasurements>
+    fn scrub<'a>(&mut self, _database: &mut B, _target: &mut T) -> io::Result<ScrubberReport>
     where
         Hash: 'a,
         Key: 'a,
     {
-        Ok(ScrubMeasurements::default())
+        Ok(ScrubberReport::Generic(ScrubMeasurements::default()))
     }
 }
 
@@ -211,7 +191,6 @@ mod tests {
         let mut total_data_size = 0;
 
         let mut database: HashMap<Vec<u8>, DataContainer<Vec<u8>>> = HashMap::new();
-        let test_data_len = test_data.len();
         for (hash, chunk) in test_data {
             total_data_size += chunk.len();
             database.insert(hash.clone(), DataContainer::from(chunk));
@@ -221,26 +200,13 @@ mod tests {
         let mut scrubber = CopyScrubber;
         let scrub_report = scrubber.scrub(&mut database, &mut target_map).unwrap();
 
-        assert_eq!(scrub_report.processed_data, total_data_size);
-        assert!(scrub_report.running_time > Duration::from_secs(0));
-        assert_eq!(scrub_report.data_left, 0);
-
-        let cluster_report = &scrub_report.clusterization_report;
-        assert_eq!(cluster_report.total_cluster_size, test_data_len);
-        assert_eq!(cluster_report.number_of_clusters, test_data_len);
-        assert!(cluster_report
-            .number_of_vertices_in_cluster
-            .values()
-            .all(|&v| v == 1));
-        assert!(cluster_report.distance_to_vertices_in_cluster.is_empty());
-        assert!(cluster_report
-            .distance_to_other_clusters
-            .values()
-            .all(|v| v.len() == test_data_len - 1));
-        assert!(cluster_report
-            .cluster_dedup_ratio
-            .values()
-            .all(|&v| v == 0.0));
+        if let ScrubberReport::Generic(measurements) = scrub_report {
+            assert_eq!(measurements.processed_data, total_data_size);
+            assert!(measurements.running_time > Duration::from_secs(0));
+            assert_eq!(measurements.data_left, 0);
+        } else {
+            panic!("Expected ScrubberReport::Generic variant");
+        }
     }
 
     #[test]
@@ -251,9 +217,12 @@ mod tests {
 
         let scrub_report = scrubber.scrub(&mut database, &mut target_map).unwrap();
 
-        assert_eq!(scrub_report.processed_data, 0);
-        assert_eq!(scrub_report.data_left, 0);
-        assert_eq!(scrub_report.clusterization_report.total_cluster_size, 0);
+        if let ScrubberReport::Generic(measurements) = scrub_report {
+            assert_eq!(measurements.processed_data, 0);
+            assert_eq!(measurements.data_left, 0);
+        } else {
+            panic!("Expected ScrubberReport::Generic variant");
+        }
         assert!(target_map.is_empty());
     }
 }

--- a/src/system/storage.rs
+++ b/src/system/storage.rs
@@ -3,11 +3,10 @@ use std::fmt::Formatter;
 use std::io;
 use std::time::{Duration, Instant};
 
+use super::database::{Database, IterableDatabase};
+use super::scrub::{Scrub, ScrubberReport};
 use crate::{ChunkHash, Hasher, SEG_SIZE};
 use crate::{ChunkerRef, WriteMeasurements};
-
-use super::database::{Database, IterableDatabase};
-use super::scrub::{Scrub, ScrubMeasurements};
 
 /// Container for storage data.
 #[derive(Clone, Debug, Default)]
@@ -177,7 +176,7 @@ where
         }
     }
 
-    pub fn scrub(&mut self) -> io::Result<ScrubMeasurements> {
+    pub fn scrub(&mut self) -> io::Result<ScrubberReport> {
         self.scrubber
             .as_mut()
             .ok_or_else(|| {
@@ -435,14 +434,14 @@ impl<K> Default for Data<K> {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
-
     use super::ChunkStorage;
     use super::DataContainer;
-    use super::ScrubMeasurements;
     use crate::chunkers::{FSChunker, SuperChunker};
     use crate::hashers::SimpleHasher;
     use crate::system::scrub::DumbScrubber;
+    use crate::system::ScrubberReport;
+    use crate::ScrubMeasurements;
+    use std::collections::HashMap;
 
     #[test]
     fn hashmap_works_as_cdc_map() {
@@ -463,7 +462,10 @@ mod tests {
             .unwrap()
             .scrub(&mut chunk_storage.database, &mut chunk_storage.target_map)
             .unwrap();
-        assert_eq!(measurements, ScrubMeasurements::default());
+        assert_eq!(
+            measurements,
+            ScrubberReport::Generic(ScrubMeasurements::default())
+        );
 
         println!("{:?}", chunk_storage.database)
     }


### PR DESCRIPTION
…bberReport enum

New ScrubberReport enum allows any scrubber type to be easily added with additional information, e.g., cluster data. Clustering metrics computation removed from CopyScrubber.