### PR TITLE
refactor: split database.rs into database/ module with separate hashm…

### DIFF
--- a/src/system/database/hashmap.rs
+++ b/src/system/database/hashmap.rs
@@ -1,0 +1,37 @@
+use std::collections::HashMap;
+use std::io;
+use std::io::ErrorKind;
+
+use crate::ChunkHash;
+
+use super::{Database, IterableDatabase};
+
+impl<Hash: ChunkHash, V: Clone> Database<Hash, V> for HashMap<Hash, V> {
+    fn insert(&mut self, key: Hash, value: V) -> io::Result<()> {
+        self.entry(key).or_insert(value);
+        Ok(())
+    }
+
+    fn get(&self, key: &Hash) -> io::Result<V> {
+        self.get(key).ok_or(ErrorKind::NotFound.into()).cloned()
+    }
+
+    fn contains(&self, key: &Hash) -> bool {
+        self.contains_key(key)
+    }
+}
+
+impl<Hash: ChunkHash, V: Clone> IterableDatabase<Hash, V> for HashMap<Hash, V> {
+    fn iterator(&self) -> Box<dyn Iterator<Item = (&Hash, &V)> + '_> {
+        Box::new(self.iter())
+    }
+
+    fn iterator_mut(&mut self) -> Box<dyn Iterator<Item = (&Hash, &mut V)> + '_> {
+        Box::new(self.iter_mut())
+    }
+
+    fn clear(&mut self) -> io::Result<()> {
+        HashMap::clear(self);
+        Ok(())
+    }
+}

--- a/src/system/database/mod.rs
+++ b/src/system/database/mod.rs
@@ -1,8 +1,6 @@
-use std::collections::HashMap;
 use std::io;
-use std::io::ErrorKind;
 
-use crate::ChunkHash;
+pub mod hashmap;
 
 /// Serves as base functionality for storing the actual data as key-value pairs.
 ///
@@ -69,34 +67,4 @@ pub trait IterableDatabase<K, V>: Database<K, V> {
 
     /// Clears the database, removing all contained key-value pairs.
     fn clear(&mut self) -> io::Result<()>;
-}
-
-impl<Hash: ChunkHash, V: Clone> Database<Hash, V> for HashMap<Hash, V> {
-    fn insert(&mut self, key: Hash, value: V) -> io::Result<()> {
-        self.entry(key).or_insert(value);
-        Ok(())
-    }
-
-    fn get(&self, key: &Hash) -> io::Result<V> {
-        self.get(key).ok_or(ErrorKind::NotFound.into()).cloned()
-    }
-
-    fn contains(&self, key: &Hash) -> bool {
-        self.contains_key(key)
-    }
-}
-
-impl<Hash: ChunkHash, V: Clone> IterableDatabase<Hash, V> for HashMap<Hash, V> {
-    fn iterator(&self) -> Box<dyn Iterator<Item = (&Hash, &V)> + '_> {
-        Box::new(self.iter())
-    }
-
-    fn iterator_mut(&mut self) -> Box<dyn Iterator<Item = (&Hash, &mut V)> + '_> {
-        Box::new(self.iter_mut())
-    }
-
-    fn clear(&mut self) -> io::Result<()> {
-        HashMap::clear(self);
-        Ok(())
-    }
 }


### PR DESCRIPTION
Refactored `database.rs` into the `database/` module:
- `Database` and `IterableDatabase` traits moved to `database/mod.rs`
- `HashMap` implementations moved to `database/hashmap.rs`
- All imports remain unchanged, full backward compatibility preserved