### PR TITLE
fix(storage): reset size_written only after successful clear

### DIFF
--- a/src/system/storage.rs
+++ b/src/system/storage.rs
@@ -236,8 +236,9 @@ where
 
     /// Removes all stored data in the database and sets written size to 0.
     pub fn clear_database(&mut self) -> io::Result<()> {
+        self.database.clear()?;
         self.size_written = 0;
-        self.database.clear()
+        Ok(())
     }
 }
 
@@ -262,9 +263,10 @@ where
 
     /// Removes all stored data in the target map and sets written size to 0.
     pub fn clear_database_full(&mut self) -> io::Result<()> {
-        self.size_written = 0;
         self.database.clear()?;
-        self.target_map.clear()
+        self.target_map.clear()?;
+        self.size_written = 0;
+        Ok(())
     }
 }
 


### PR DESCRIPTION
Problem:
In both clear_database and clear_database_full methods of ChunkStorage, the size_written counter was being reset to 0 before calling the fallible database.clear(). If clear() returns an Err, the method propagates the error to the caller, but size_written has already been zeroed. This leaves the storage in an inconsistent state: the database still contains all data, yet the byte counter indicates that nothing has been written.

Fix:
Reordered the operations so that size_written is updated only after all fallible operations have succeeded:
- clear_database: database.clear()? → size_written = 0 → Ok(())
- clear_database_full: database.clear()? → target_map.clear()? → size_written = 0 → Ok(())
With this fix, if clear() fails, the state remains consistent: the database is untouched and size_written still reflects the actual amount of stored data.